### PR TITLE
Filter RPC byte generation for prefixes

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/ForgeNetworkingEditor.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/ForgeNetworkingEditor.cs
@@ -807,6 +807,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 
 					constRpc += btn.RPCVariables[i].FieldName[j].ToString().ToUpper();
 				}
+				constRpc = constRpc.Replace("R_P_C_", "");
 
 				object[] constRpcData = new object[]
 				{


### PR DESCRIPTION
Added filter to prevent RPC const byte name generation from turning methods beginning with the "RPC" prefix from becoming verbose, i.e.:

Method name- RPCTest
Byte name previous: RPC_R_P_C_TEST, current: RPC_TEST