### PR TITLE
Update MultiplayerMenu.cs

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Multiplayer Menu/MultiplayerMenu.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Multiplayer Menu/MultiplayerMenu.cs
@@ -74,11 +74,16 @@ public class MultiplayerMenu : MonoBehaviour
 			ConnectToMatchmaking();
 			return;
 		}
-		int port = ushort.Parse(portNumber.text);
-		if (port < 0 || port > ushort.MaxValue)
+		int port = -1;
+		try
 		{
-			Debug.LogError("The supplied port number is not within the allowed range 0-" + ushort.MaxValue);
-			return;
+		    port = ushort.Parse(portNumber.text); ;
+		}
+		catch (System.Exception)
+		{
+		    //You could generate here an event for your game GUI
+		    Debug.LogError("The supplied port number is not within the allowed range 0-" + ushort.MaxValue);
+		    return;
 		}
 
 		NetWorker client;


### PR DESCRIPTION
Hi all, I think that I've found a minor bug related to MultiplayerMenu.cs script at line 77 in method "Connect()" . Infact if you specify an incorrect port number (e.g. 65536) and press "connect", an OverflowException is generated. Therefore, the consequent instruction "if (port < 0 || port > ushort.MaxValue)" is useless because it cannot be reached. What do you think about?