### PR TITLE
NetworkObjects call base class when ownership changes

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkObjectTemplate.txt
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkObjectTemplate.txt
@@ -53,6 +53,7 @@ namespace BeardedManStudios.Forge.Networking.Generated
 
 		protected override void OwnershipChanged()
 		{
+			base.OwnershipChanged();
 			SnapInterpolations();
 		}
 		


### PR DESCRIPTION
When transferring ownership, the base `NetworkObject` class wasn't being called here. This was preventing the `ownershipChanged` event from firing on the server. Calling the base class results in `ownershipChanged` being properly fired, as expected.