### PR TITLE
Fixed float parsing/generating with non-dot decimal separator

### DIFF
--- a/BeardedManStudios/Source/SimpleJSON.cs
+++ b/BeardedManStudios/Source/SimpleJSON.cs
@@ -44,6 +44,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 
@@ -173,13 +174,13 @@ namespace BeardedManStudios.SimpleJSON
 			get
 			{
 				float v = 0.0f;
-				if (float.TryParse(Value, out v))
+				if (float.TryParse(Value, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out v))
 					return v;
 				return 0.0f;
 			}
 			set
 			{
-				Value = value.ToString();
+				Value = value.ToString(CultureInfo.InvariantCulture);
 				Tag = JSONBinaryTag.FloatValue;
 			}
 		}
@@ -189,13 +190,13 @@ namespace BeardedManStudios.SimpleJSON
 			get
 			{
 				double v = 0.0;
-				if (double.TryParse(Value, out v))
+				if (double.TryParse(Value, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out v))
 					return v;
 				return 0.0;
 			}
 			set
 			{
-				Value = value.ToString();
+				Value = value.ToString(CultureInfo.InvariantCulture);
 				Tag = JSONBinaryTag.DoubleValue;
 
 			}

--- a/ForgeNetworkingCommon/Templating/TemplateSystem.cs
+++ b/ForgeNetworkingCommon/Templating/TemplateSystem.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace BeardedManStudios.Templating
@@ -230,9 +231,11 @@ namespace BeardedManStudios.Templating
 			if (data is bool)
 				return data.ToString().ToLower();
 			else if (data is float)
-				return data.ToString() + "f";
-
-			return data.ToString();
+			{
+			    float fData = (float) data;
+			    return fData.ToString(CultureInfo.InvariantCulture) + "f";
+            }
+            return data.ToString();
 		}
 	}
 }

--- a/ForgeNetworkingUnityEditor/ForgeNetworkingUnityEditor.csproj
+++ b/ForgeNetworkingUnityEditor/ForgeNetworkingUnityEditor.csproj
@@ -33,10 +33,10 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="UnityEditor">
-      <HintPath>C:\Program Files\Unity\Editor\Data\Managed\UnityEditor.dll</HintPath>
+      <HintPath>..\Forge Networking Remastered Unity\Library\UnityAssemblies\UnityEditor.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\Forge Networking Remastered Unity\Library\UnityAssemblies\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ForgeNetworkingUnityEditor/SimpleJSONEditor.cs
+++ b/ForgeNetworkingUnityEditor/SimpleJSONEditor.cs
@@ -44,6 +44,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 
@@ -369,7 +370,7 @@ namespace SimpleJSONEditor
 				return new JSONData(integer);
 			}
 
-			if (double.TryParse(token, out real))
+			if (double.TryParse(token, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out real))
 			{
 				return new JSONData(real);
 			}

--- a/UnitTests/Source/UnityEditor/JSONNodeTests.cs
+++ b/UnitTests/Source/UnityEditor/JSONNodeTests.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SimpleJSONEditor;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SimpleJSONEditor.Tests
+{
+    [TestClass()]
+    public class JSONNodeTests
+    {
+        [TestMethod()]
+        public void ParseInvariantCultureTest()
+        {
+            var storedCulture = Thread.CurrentThread.CurrentCulture;
+            JSONNode jsonNode;
+            float expected = 0.15f;
+            float actual;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+                var jsonString = String.Format("{{ floatTest: {0} }}", expected.ToString(CultureInfo.InvariantCulture));
+                jsonNode = SimpleJSONEditor.JSON.Parse(jsonString);
+                actual = jsonNode.Children.FirstOrDefault().AsFloat;
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = storedCulture;
+            }
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod()]
+        public void ParseCommaDecimalSeparatorCultureTest()
+        {
+            var storedCulture = Thread.CurrentThread.CurrentCulture;
+            JSONNode jsonNode;
+            float expected = 0.15f;
+            float actual;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("fi-FI");
+                var jsonString = String.Format("{{ floatTest: {0} }}", expected.ToString(CultureInfo.InvariantCulture));
+                jsonNode = SimpleJSONEditor.JSON.Parse(jsonString);
+                actual = jsonNode.Children.FirstOrDefault().AsFloat;
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = storedCulture;
+            }
+            //var floatValue = jsonNode.AsFloat;
+            Assert.AreEqual(expected, actual);
+        }
+
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -66,6 +66,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Source\UnityEditor\JSONNodeTests.cs" />
     <Compile Include="Source\BaseTest.cs" />
     <Compile Include="Source\FrameTests.cs" />
     <Compile Include="Source\BMSByteTests.cs" />
@@ -94,6 +95,10 @@
     <ProjectReference Include="..\..\ForgeNetworkingRemastered\ForgeNetworkingCommon\ForgeNetworkingCommon.csproj">
       <Project>{9c3af9d0-b19f-44a6-9068-84b636892bde}</Project>
       <Name>ForgeNetworkingCommon</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ForgeNetworkingUnityEditor\ForgeNetworkingUnityEditor.csproj">
+      <Project>{6BDD215D-6E48-4D61-9C44-A3188EC18DF1}</Project>
+      <Name>ForgeNetworkingUnityEditor</Name>
     </ProjectReference>
   </ItemGroup>
   <Choose>


### PR DESCRIPTION
Added some ToString formatting specificators on float handling to support culture-specific decimal separator. Included some very basic unit tests for main parsing part, didn't add tests for generator parts.

Also made the Unity assembly references to be relative on ForgeNetworkingUnityEditor project, as it failed to get the Unity-created references.