### PR TITLE
Some fixes (critical and not)

### DIFF
--- a/BeardedManStudios/Source/BMSByte.cs
+++ b/BeardedManStudios/Source/BMSByte.cs
@@ -33,7 +33,7 @@ namespace BeardedManStudios
 		/// <summary>
 		/// A lookup of various types that are allowed to be stored and pulled from this object
 		/// </summary>
-		private static Dictionary<Type, Array> allowedTypes = new Dictionary<Type, Array>()
+		private Dictionary<Type, Array> allowedTypes = new Dictionary<Type, Array>()
 		{
 			{ typeof(char), new char[1] },
 			{ typeof(string), new string[1] },

--- a/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
+++ b/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
@@ -929,15 +929,19 @@ namespace BeardedManStudios.Forge.Networking
 		/// <summary>
 		/// Used to bind to a port then unbind to trigger any operating system firewall requests
 		/// </summary>
-		public static void PingForFirewall()
+		public static void PingForFirewall(ushort port = 0)
 		{
+			if (port < 1)
+			{
+				port = DEFAULT_PORT - 1;
+			}
 			Task.Queue(() =>
 			{
 				try
 				{
 					//IPAddress ipAddress = Dns.GetHostEntry(Dns.GetHostName()).AddressList[0];
 					//IPEndPoint ipLocalEndPoint = new IPEndPoint(ipAddress, 15937);
-					IPEndPoint ipLocalEndPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), DEFAULT_PORT);
+					IPEndPoint ipLocalEndPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), port);
 
 					System.Net.Sockets.TcpListener t = new System.Net.Sockets.TcpListener(ipLocalEndPoint);
 					t.Start();

--- a/BeardedManStudios/Source/Forge/Networking/NetworkingPlayer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/NetworkingPlayer.cs
@@ -348,7 +348,8 @@ namespace BeardedManStudios.Forge.Networking
 									// Remove 
 									lock (reliableComposers)
 									{
-										reliableComposers.Remove(reliableComposers.First(r => r.Frame.UniqueId == reliableComposersToRemove.Dequeue()));
+										ulong id = reliableComposersToRemove.Dequeue();
+										reliableComposers.Remove(reliableComposers.First(r => r.Frame.UniqueId == id));
 									}
 								}
 							}

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkManagerTemplate.txt
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkManagerTemplate.txt
@@ -21,7 +21,8 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 		private void OnDestroy()
 		{
-			Networker.objectCreated -= CaptureObjects;
+		    if (Networker != null)
+				Networker.objectCreated -= CaptureObjects;
 		}
 		
 		private void CaptureObjects(NetworkObject obj)

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Multiplayer Menu/MultiplayerMenu.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Multiplayer Menu/MultiplayerMenu.cs
@@ -49,7 +49,7 @@ public class MultiplayerMenu : MonoBehaviour
 		if (!useTCP)
 		{
 			// Do any firewall opening requests on the operating system
-			NetWorker.PingForFirewall();
+			NetWorker.PingForFirewall(ushort.Parse(portNumber.text));
 		}
 
 		if (useMainThreadManagerForRPCs)

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -451,8 +451,8 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 				MainThreadManager.Run(() =>
 				{
-					//if (loadedScenes.Count == 0)
-					//	return;
+					if (loadedScenes.Count == 0)
+						return;
 
 					SceneManager.LoadScene(loadedScenes[0], LoadSceneMode.Single);
 


### PR DESCRIPTION
- Removed 'static' from BMSByte allowedTypes dictionary, so it will not collide with other Threads
- Added an ability to set firewall port on PingForFirewall() method (prevent collisions between two Networkers on connection stage)
- Fixed a bug of LINQ usage in reliableComposers (raised freezes sometimes on huge UDP stream)
- Added a check of Networker to NetworkManagerTemplate.txt, because it can be already removed on NetworkManager Destroy
- Uncommented check of loadedScenes.Count which raised an error if no loadedScenes used