### PR TITLE
Call "CompleteRegistration()" before "networkStarted(this)"

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkBehavior.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkBehavior.cs
@@ -22,10 +22,10 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 		protected virtual void NetworkStart()
 		{
+			CompleteRegistration();
+
 			if (networkStarted != null)
 				networkStarted(this);
-
-			CompleteRegistration();
 		}
 
 		protected virtual void CompleteRegistration() { }


### PR DESCRIPTION
This seems to have fixed the issue with not being able to call RPCs from the `networkStarted` event.  I haven't tested it thoroughly, but it seems to be working so far.