### PR TITLE
LAN Discovery fix after disconnect

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
+++ b/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
@@ -1040,7 +1040,7 @@ namespace BeardedManStudios.Forge.Networking
 
 				try
 				{
-					while (localListingsClient != null && !EndingSession)
+					while (localListingsClient != null)
 					{
 						var data = localListingsClient.Receive(ref groupEp, ref endpoint);
 


### PR DESCRIPTION
EndingSession is incorrectly true after disconnecting and then trying LAN Discovery again (before connecting as a client/or hosting a server).

EndingSession bool is set to false in Initialize().  but Initialize() is only called when creating a server or connecting as a client; thus in some cases LAN Discovery is done before Initialize() so the EndingSession is incorrectly false.


