### PR TITLE
Exclude TCPClientWebsockets on mobile builds

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Server Browser/ServerBrowser.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Server Browser/ServerBrowser.cs
@@ -115,12 +115,13 @@ namespace BeardedManStudios.Forge.Networking.Unity
 										socket = new TCPClient();
 										((TCPClient)socket).Connect(address, port);
 									}
+									#if !UNITY_IOS && !UNITY_ANDROID
 									else if (protocol == "web")
 									{
 										socket = new TCPClientWebsockets();
 										((TCPClientWebsockets)socket).Connect(address, port);
 									}
-
+									#endif
 									if (socket == null)
 										throw new Exception("No socket of type " + protocol + " could be established");
 


### PR DESCRIPTION
For iOS and Android TCPClientWebsockets aren't needed and cause the build to fail.

Removing them through Unity preprocessing conditionals resolve the build issue on the mobile platforms