### PR TITLE
Fixed unity crash when connection to master server failed

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
+++ b/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
@@ -287,24 +287,27 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="forced">Used to tell if this disconnect was intentional <c>false</c> or caused by an exception <c>true</c></param>
 		public override void Disconnect(bool forced)
 		{
-			lock (client)
+			if (client != null)
 			{
-				disconnectedSelf = true;
+				lock (client)
+				{
+					disconnectedSelf = true;
 
-				// Close our TcpClient so that it can no longer be used
-				if (forced)
-					client.Close();
-				else
-					Send(new ConnectionClose(Time.Timestep, true, Receivers.Server, MessageGroupIds.DISCONNECT, true));
+					// Close our TcpClient so that it can no longer be used
+					if (forced)
+						client.Close();
+					else
+						Send(new ConnectionClose(Time.Timestep, true, Receivers.Server, MessageGroupIds.DISCONNECT, true));
 
-				// Send signals to the methods registered to the disconnec events
-				if (!forced)
-					OnDisconnected();
-				else
-					OnForcedDisconnect();
+					// Send signals to the methods registered to the disconnec events
+					if (!forced)
+						OnDisconnected();
+					else
+						OnForcedDisconnect();
 
-				for (int i = 0; i < Players.Count; ++i)
-					OnPlayerDisconnected(Players[i]);
+					for (int i = 0; i < Players.Count; ++i)
+						OnPlayerDisconnected(Players[i]);
+				}
 			}
 		}
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -245,6 +245,12 @@ namespace BeardedManStudios.Forge.Networking.Unity
 					//Debug.Log(temp.GetData().Length);
 					// Send the request to the server
 					client.Send(temp);
+
+					Networker.disconnected += s =>
+					{
+						client.Disconnect(false);
+						MasterServerNetworker = null;
+					};
 				}
 				catch
 				{
@@ -256,11 +262,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 			client.Connect(_masterServerHost, _masterServerPort);
 
-			Networker.disconnected += (sender) =>
-			{
-				client.Disconnect(false);
-				MasterServerNetworker = null;
-			};
+			
 
 			MasterServerNetworker = client;
 		}

--- a/MasterServer/Program.cs
+++ b/MasterServer/Program.cs
@@ -33,8 +33,6 @@ namespace MasterServer
 				read = Console.ReadLine();
 				if (string.IsNullOrEmpty(read))
 					host = "0.0.0.0";
-				else
-					host = read;
 
 				Console.WriteLine("Enter Port (Default: 15940):");
 				read = Console.ReadLine();

--- a/MasterServer/Program.cs
+++ b/MasterServer/Program.cs
@@ -33,6 +33,8 @@ namespace MasterServer
 				read = Console.ReadLine();
 				if (string.IsNullOrEmpty(read))
 					host = "0.0.0.0";
+				else
+					host = read;
 
 				Console.WriteLine("Enter Port (Default: 15940):");
 				read = Console.ReadLine();


### PR DESCRIPTION
Crash occurs few seconds after hitting Stop button.

Those two changes fix the same issue so only one of them is needed. Not sure which one is better.

![195cbcaa153d0495f51c0f82f06cebfc](https://user-images.githubusercontent.com/9093037/30007021-9063f654-9105-11e7-982f-037dd20f2c44.png)
