### PR TITLE
Call NetworkStart() after setting position

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
@@ -28,12 +28,6 @@ namespace BeardedManStudios.Forge.Networking.Generated
 			networkObject.RegisterRpc(">:[0]:<", >:[0]:<>:[1]:<);
 			>:ENDFOREVERY:<
 
-			MainThreadManager.Run(() =>
-			{
-				NetworkStart();
-				networkObject.Networker.FlushCreateActions(networkObject);
-			});
-
 			networkObject.onDestroy += DestroyGameObject;
 
 			if (!obj.IsOwner)
@@ -72,6 +66,12 @@ namespace BeardedManStudios.Forge.Networking.Generated
 			{
 				MainThreadManager.Run(() => { transform.rotation = ObjectMapper.Instance.Map<Quaternion>(metadataTransform); });
 			}
+
+			MainThreadManager.Run(() =>
+			{
+				NetworkStart();
+				networkObject.Networker.FlushCreateActions(networkObject);
+			});
 		}
 
 		protected override void CompleteRegistration()


### PR DESCRIPTION
Related to issue #66 

`transform.position` was being set after `NetworkStart()` was called, so getting or setting `transform.position` in `NetworkStart()` could result in unexpected behavior depending on the situation.

This simply just moves the line that calls `NetworkStart()` below the lines that set the `transform.position`.

NCW will need to be saved in order to re-generate everything to see any changes.