### PR TITLE
Shortcut for quick BMSByte creation

### DIFF
--- a/BeardedManStudios/Source/Forge/DataStore/Cache.cs
+++ b/BeardedManStudios/Source/Forge/DataStore/Cache.cs
@@ -117,8 +117,7 @@ namespace BeardedManStudios.Forge.Networking.DataStore
 				if (obj == null)
 					return;
 
-				BMSByte data = new BMSByte();
-				ObjectMapper.Instance.MapBytes(data, type, responseHookId, obj);
+				BMSByte data = ObjectMapper.BMSByte(type, responseHookId, obj);
 
 				Binary sendFrame = new Binary(sender.Time.Timestep, sender is TCPClient, data, Receivers.Target, MessageGroupIds.CACHE, sender is BaseTCP);
 
@@ -224,7 +223,6 @@ namespace BeardedManStudios.Forge.Networking.DataStore
 
 			responseHooks.Add(responseHookIncrementer, callback);
 
-			BMSByte data = new BMSByte();
 			byte targetType = byte.MaxValue;
 
 			foreach (KeyValuePair<byte, Type> kv in typeMap)
@@ -239,7 +237,7 @@ namespace BeardedManStudios.Forge.Networking.DataStore
 			if (targetType == byte.MaxValue)
 				throw new Exception("Invalid type specified");
 
-			ObjectMapper.Instance.MapBytes(data, targetType, responseHookIncrementer, key);
+			BMSByte data = ObjectMapper.BMSByte(targetType, responseHookIncrementer, key);
 
 			Binary sendFrame = new Binary(Socket.Time.Timestep, Socket is TCPClient, data, Receivers.Server, MessageGroupIds.CACHE, Socket is BaseTCP);
 

--- a/BeardedManStudios/Source/Forge/Networking/ObjectMapper.cs
+++ b/BeardedManStudios/Source/Forge/Networking/ObjectMapper.cs
@@ -347,5 +347,17 @@ namespace BeardedManStudios.Forge.Networking
 				throw new BaseNetworkException("The type " + type.ToString() + " is not allowed to be sent over the Network (yet)");
 			}
 		}
+
+		
+		/// <summary>
+		/// Creates a BMSByte using ObjectMapper
+		/// </summary>
+		/// <param name="argsToMap">Objects to be mapped</param>
+		public static BMSByte BMSByte(params object[] argsToMap)
+		{
+			BMSByte data = new BMSByte();
+			Instance.MapBytes(data, argsToMap);
+			return data;
+		}
 	}
 }

--- a/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
+++ b/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
@@ -362,8 +362,6 @@ namespace BeardedManStudios.Forge.Networking
 				// This is a client so it needs to request the creation by the server
 				NetworkReady = false;
 
-				BMSByte data = new BMSByte();
-
 				// Create a hash for this object so it knows that the response from the server is
 				// for this particular create and not another one
 				hash = GlobalHash == -1 ? (GlobalHash += 2) : ++GlobalHash;
@@ -374,7 +372,7 @@ namespace BeardedManStudios.Forge.Networking
 				Networker.objectCreateAttach += CreatedOnNetwork;
 				//TODO: MOVED HERE (#1)
 
-				ObjectMapper.Instance.MapBytes(data, UniqueIdentity, hash, CreateCode);
+				BMSByte data = ObjectMapper.BMSByte(UniqueIdentity, hash, CreateCode);
 				WritePayload(data);
 
 				// Write if the object has metadata
@@ -454,8 +452,7 @@ namespace BeardedManStudios.Forge.Networking
 				if (frame.StreamData.GetBasicType<bool>())
 					Metadata = ObjectMapper.Instance.Map<byte[]>(frame.StreamData);
 
-				BMSByte createdByteData = new BMSByte();
-				ObjectMapper.Instance.MapBytes(createdByteData, serverId);
+				BMSByte createdByteData = ObjectMapper.BMSByte(serverId);
 
 				Binary createdFrame = new Binary(Networker.Time.Timestep, Networker is TCPClient, createdByteData, Receivers.Server, MessageGroupIds.GetId("NO_CREATED_" + NetworkId), Networker is BaseTCP, RouterIds.CREATED_OBJECT_ROUTER_ID);
 
@@ -617,8 +614,7 @@ namespace BeardedManStudios.Forge.Networking
 			}
 
 			// The data that is to be sent to all the clients who did not request this object to be created
-			BMSByte data = new BMSByte();
-			ObjectMapper.Instance.MapBytes(data, UniqueIdentity, targetHash, NetworkId, CreateCode);
+			BMSByte data = ObjectMapper.BMSByte(UniqueIdentity, targetHash, NetworkId, CreateCode);
 
 			// Write all of the most up to date data for this object
 			WritePayload(data);
@@ -677,8 +673,7 @@ namespace BeardedManStudios.Forge.Networking
 						networker = obj.Networker;
 					}
 
-					BMSByte indexBytes = new BMSByte();
-					ObjectMapper.Instance.MapBytes(indexBytes, indexes.Count);
+					BMSByte indexBytes = ObjectMapper.BMSByte(indexes.Count);
 					for (int i = 0; i < indexes.Count; i++)
 						ObjectMapper.Instance.MapBytes(indexBytes, indexes[i]);
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -426,8 +426,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		/// <param name="player">The player that was just accepted</param>
 		private void PlayerAcceptedSceneSetup(NetworkingPlayer player, NetWorker sender)
 		{
-			BMSByte data = new BMSByte();
-			ObjectMapper.Instance.MapBytes(data, loadedScenes.Count);
+			BMSByte data = ObjectMapper.BMSByte(loadedScenes.Count);
 
 			// Go through all the loaded scene indexes and send them to the connecting player
 			for (int i = 0; i < loadedScenes.Count; i++)
@@ -553,8 +552,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			if (networkSceneLoaded != null)
 				networkSceneLoaded(scene, mode);
 
-			BMSByte data = new BMSByte();
-			ObjectMapper.Instance.MapBytes(data, scene.buildIndex, (int)mode);
+			BMSByte data = ObjectMapper.BMSByte(scene.buildIndex, (int)mode);
 
 			Binary frame = new Binary(Networker.Time.Timestep, false, data, Networker is IServer ? Receivers.All : Receivers.Server, MessageGroupIds.VIEW_CHANGE, Networker is BaseTCP);
 

--- a/UnitTests/Source/FrameTests.cs
+++ b/UnitTests/Source/FrameTests.cs
@@ -52,8 +52,7 @@ namespace UnitTests
 
 		private Binary SendBinary(NetWorker networker)
 		{
-			BMSByte data = new BMSByte();
-			ObjectMapper.Instance.MapBytes(data, MESSAGE);
+			BMSByte data = ObjectMapper.BMSByte(MESSAGE);
 
 			ulong timestep = (ulong)(DateTime.UtcNow - start).TotalMilliseconds;
 			return new Binary(timestep, networker is TCPClient, data, Receivers.Target, 17931, networker is BaseTCP);

--- a/UnitTests/Source/UDP/ReliablePacketTests.cs
+++ b/UnitTests/Source/UDP/ReliablePacketTests.cs
@@ -44,8 +44,7 @@ namespace UnitTests.Source.UDP
 
 		private Binary SendBinary(NetWorker networker)
 		{
-			BMSByte data = new BMSByte();
-			ObjectMapper.Instance.MapBytes(data, MESSAGE);
+			BMSByte data = ObjectMapper.BMSByte(MESSAGE);
 
 			ulong timestep = (ulong)(DateTime.UtcNow - start).TotalMilliseconds;
 			return new Binary(timestep, networker is TCPClient, data, Receivers.Target, 17931, networker is BaseTCP);


### PR DESCRIPTION
Instead of:
BMSByte data = new BMSByte();
ObjectMapper.Instance.MapBytes(data, obejct[] args);

It's just:
BMSByte data = ObjectMapper.BMSByte(obejct[] args);