### PR TITLE
Optimization of multiple objects serialization

### DIFF
--- a/BeardedManStudios/Source/BMSByte.cs
+++ b/BeardedManStudios/Source/BMSByte.cs
@@ -31,6 +31,26 @@ namespace BeardedManStudios
 	public sealed class BMSByte
 	{
 		/// <summary>
+		/// A lookup of various types that are allowed to be stored and pulled from this object
+		/// </summary>
+		private static Dictionary<Type, Array> allowedTypes = new Dictionary<Type, Array>()
+		{
+			{ typeof(char), new char[1] },
+			{ typeof(string), new string[1] },
+			{ typeof(bool), new bool[1] },
+			{ typeof(sbyte), new sbyte[1] },
+			{ typeof(byte), new byte[1] },
+			{ typeof(short), new short[1] },
+			{ typeof(ushort), new ushort[1] },
+			{ typeof(int), new int[1] },
+			{ typeof(uint), new uint[1] },
+			{ typeof(long), new long[1] },
+			{ typeof(ulong), new ulong[1] },
+			{ typeof(float), new float[1] },
+			{ typeof(double), new double[1] },
+		};
+
+		/// <summary>
 		/// The current read/write index for this object
 		/// </summary>
 		private int index = 0;
@@ -370,10 +390,12 @@ namespace BeardedManStudios
 		private Array GetArray<T>(object o)
 		{
 			Type type = typeof(T);
-			if (type == typeof(sbyte) || type == typeof(byte) || type == typeof(char) || type == typeof(bool) || type == typeof(short) || type == typeof(ushort) || type == typeof(int) ||
-				type == typeof(uint) || type == typeof(long) || type == typeof(ulong) || type == typeof(float) || type == typeof(double))
+			if (allowedTypes.ContainsKey(type))
 			{
-				return new T[1] { (T)o };
+				T[] array = (T[])allowedTypes[type];
+				array[0] = (T)o;
+				return array;
+
 			}
 			else
 				throw new Exception("The type " + type.ToString() + " is not allowed");

--- a/BeardedManStudios/Source/BMSByte.cs
+++ b/BeardedManStudios/Source/BMSByte.cs
@@ -31,26 +31,6 @@ namespace BeardedManStudios
 	public sealed class BMSByte
 	{
 		/// <summary>
-		/// A lookup of various types that are allowed to be stored and pulled from this object
-		/// </summary>
-		private Dictionary<Type, Array> allowedTypes = new Dictionary<Type, Array>()
-		{
-			{ typeof(char), new char[1] },
-			{ typeof(string), new string[1] },
-			{ typeof(bool), new bool[1] },
-			{ typeof(sbyte), new sbyte[1] },
-			{ typeof(byte), new byte[1] },
-			{ typeof(short), new short[1] },
-			{ typeof(ushort), new ushort[1] },
-			{ typeof(int), new int[1] },
-			{ typeof(uint), new uint[1] },
-			{ typeof(long), new long[1] },
-			{ typeof(ulong), new ulong[1] },
-			{ typeof(float), new float[1] },
-			{ typeof(double), new double[1] },
-		};
-
-		/// <summary>
 		/// The current read/write index for this object
 		/// </summary>
 		private int index = 0;
@@ -231,7 +211,7 @@ namespace BeardedManStudios
 			if (obj is string)
 				Buffer.BlockCopy(Encoding.UTF8.GetBytes(((string)obj)), 0, byteArr, index, count);
 			else
-				Buffer.BlockCopy(GetArray(typeof(T), obj), 0, byteArr, index, count);
+				Buffer.BlockCopy(GetArray<T>(obj), 0, byteArr, index, count);
 
 			Size = index + count;
 			PointToEnd();
@@ -380,150 +360,24 @@ namespace BeardedManStudios
 			if (raw)
 				Append(new byte[] { 1 });
 		}
-
+		
 		/// <summary>
 		/// Get an array of a specific type from the internally tracked byte array
 		/// </summary>
 		/// <param name="type">The type of array to be pulled</param>
 		/// <param name="o"></param>
 		/// <returns>The updated array of data</returns>
-		private Array GetArray(Type type, object o)
+		private Array GetArray<T>(object o)
 		{
-			if (type == typeof(sbyte))
+			Type type = typeof(T);
+			if (type == typeof(sbyte) || type == typeof(byte) || type == typeof(char) || type == typeof(bool) || type == typeof(short) || type == typeof(ushort) || type == typeof(int) ||
+				type == typeof(uint) || type == typeof(long) || type == typeof(ulong) || type == typeof(float) || type == typeof(double))
 			{
-				((sbyte[])allowedTypes[typeof(sbyte)])[0] = (sbyte)o;
-				return allowedTypes[typeof(sbyte)];
-			}
-			else if (type == typeof(byte))
-			{
-				((byte[])allowedTypes[typeof(byte)])[0] = (byte)o;
-				return allowedTypes[typeof(byte)];
-			}
-			else if (type == typeof(char))
-			{
-				((char[])allowedTypes[typeof(char)])[0] = (char)o;
-				return allowedTypes[typeof(char)];
-			}
-			else if (type == typeof(bool))
-			{
-				((bool[])allowedTypes[typeof(bool)])[0] = (bool)o;
-				return allowedTypes[typeof(bool)];
-			}
-			else if (type == typeof(short))
-			{
-				((short[])allowedTypes[typeof(short)])[0] = (short)o;
-				return allowedTypes[typeof(short)];
-			}
-			else if (type == typeof(ushort))
-			{
-				((ushort[])allowedTypes[typeof(ushort)])[0] = (ushort)o;
-				return allowedTypes[typeof(ushort)];
-			}
-			else if (type == typeof(int))
-			{
-				((int[])allowedTypes[typeof(int)])[0] = (int)o;
-				return allowedTypes[typeof(int)];
-			}
-			else if (type == typeof(uint))
-			{
-				((uint[])allowedTypes[typeof(uint)])[0] = (uint)o;
-				return allowedTypes[typeof(uint)];
-			}
-			else if (type == typeof(long))
-			{
-				((long[])allowedTypes[typeof(long)])[0] = (long)o;
-				return allowedTypes[typeof(long)];
-			}
-			else if (type == typeof(ulong))
-			{
-				((ulong[])allowedTypes[typeof(ulong)])[0] = (ulong)o;
-				return allowedTypes[typeof(ulong)];
-			}
-			else if (type == typeof(float))
-			{
-				((float[])allowedTypes[typeof(float)])[0] = (float)o;
-				return allowedTypes[typeof(float)];
-			}
-			else if (type == typeof(double))
-			{
-				((double[])allowedTypes[typeof(double)])[0] = (double)o;
-				return allowedTypes[typeof(double)];
+				return new T[1] { (T)o };
 			}
 			else
 				throw new Exception("The type " + type.ToString() + " is not allowed");
 		}
-
-		/// <summary>
-		/// Get an array of a specific type from the internally tracked byte array
-		/// </summary>
-		/// <param name="o"></param>
-		/// <returns>The updated array of data</returns>
-		private Array GetArray(object obj)
-		{
-			if (obj is sbyte)
-			{
-				((sbyte[])allowedTypes[typeof(sbyte)])[0] = (sbyte)obj;
-				return allowedTypes[typeof(sbyte)];
-			}
-			else if (obj is byte)
-			{
-				((byte[])allowedTypes[typeof(byte)])[0] = (byte)obj;
-				return allowedTypes[typeof(byte)];
-			}
-			else if (obj is char)
-			{
-				((char[])allowedTypes[typeof(char)])[0] = (char)obj;
-				return allowedTypes[typeof(char)];
-			}
-			else if (obj is bool)
-			{
-				((bool[])allowedTypes[typeof(bool)])[0] = (bool)obj;
-				return allowedTypes[typeof(bool)];
-			}
-			else if (obj is short)
-			{
-				((short[])allowedTypes[typeof(short)])[0] = (short)obj;
-				return allowedTypes[typeof(short)];
-			}
-			else if (obj is ushort)
-			{
-				((ushort[])allowedTypes[typeof(ushort)])[0] = (ushort)obj;
-				return allowedTypes[typeof(ushort)];
-			}
-			else if (obj is int)
-			{
-				((int[])allowedTypes[typeof(int)])[0] = (int)obj;
-				return allowedTypes[typeof(int)];
-			}
-			else if (obj is uint)
-			{
-				((uint[])allowedTypes[typeof(uint)])[0] = (uint)obj;
-				return allowedTypes[typeof(uint)];
-			}
-			else if (obj is long)
-			{
-				((long[])allowedTypes[typeof(long)])[0] = (long)obj;
-				return allowedTypes[typeof(long)];
-			}
-			else if (obj is ulong)
-			{
-				((ulong[])allowedTypes[typeof(ulong)])[0] = (ulong)obj;
-				return allowedTypes[typeof(ulong)];
-			}
-			else if (obj is float)
-			{
-				((float[])allowedTypes[typeof(float)])[0] = (float)obj;
-				return allowedTypes[typeof(float)];
-			}
-			else if (obj is double)
-			{
-				((double[])allowedTypes[typeof(double)])[0] = (double)obj;
-				return allowedTypes[typeof(double)];
-			}
-			else
-				throw new Exception("The type " + obj.GetType().ToString() + " is not allowed");
-		}
-
 		/// <summary>
 		/// Used to get the size of a specific type of object, will only be types specified in the type lookup
 		/// </summary>

--- a/BeardedManStudios/Source/BMSByte.cs
+++ b/BeardedManStudios/Source/BMSByte.cs
@@ -175,6 +175,32 @@ namespace BeardedManStudios
 			PointToEnd();
 		}
 
+
+		/// <summary>
+		/// Adds the arrays of bytes to the end of the byte array and resizes only ONCE
+		/// </summary>
+		/// <param name="input">The bytes arrays to be appended to the end of the internal byte array</param>
+		public void Append(params byte[][] input)
+		{
+			int lengthSum = 0;
+			foreach (byte[] array in input)
+			{
+				lengthSum += array.Length;
+			}
+
+			if (byteArr.Length <= index + lengthSum)
+				Array.Resize<byte>(ref byteArr, index + lengthSum + 1);
+
+			foreach (byte[] array in input)
+			{
+				Buffer.BlockCopy(array, 0, byteArr, index, array.Length);
+				Size += array.Length;
+				PointToEnd();
+			}
+
+		}
+
+
 		/// <summary>
 		/// Adds the bytes to the end of the byte array and resizes when needed
 		/// </summary>

--- a/BeardedManStudios/Source/Forge/Networking/ObjectMapper.cs
+++ b/BeardedManStudios/Source/Forge/Networking/ObjectMapper.cs
@@ -22,6 +22,7 @@
 #endif
 
 using System;
+using System.IO;
 using System.Text;
 
 namespace BeardedManStudios.Forge.Networking
@@ -225,15 +226,16 @@ namespace BeardedManStudios.Forge.Networking
 		/// <returns>A byte[] of the mapped arguments</returns>
 		public BMSByte MapBytes(BMSByte bytes, params object[] args)
 		{
-			foreach (object o in args)
+			byte[][] bytesToMap = new byte[args.Length][];
+			for (int i = 0; i < args.Length; i++)
 			{
 				Type type = null;
-				if (o != null)
-					type = o.GetType();
+				if (args[i] != null)
+					type = args[i].GetType();
 
-				GetBytes(o, type, ref bytes);
+				bytesToMap[i] = GetBytesArray(args[i], type);
 			}
-
+			bytes.Append(bytesToMap);
 			return bytes;
 		}
 
@@ -348,7 +350,139 @@ namespace BeardedManStudios.Forge.Networking
 			}
 		}
 
-		
+		/// <summary>
+		/// Gets the bytes array for the Instance of an Object
+		/// </summary>
+		/// <param name="o">The Instance of the Object.</param>
+		/// <param name="type">The Type of the Object.</param>
+		protected virtual byte[] GetBytesArray(object o, Type type)
+		{
+			if (type == typeof(string))
+			{
+				var strBytes = Encoding.UTF8.GetBytes(o == null ? string.Empty : (string)o);
+				byte[] bytes = new byte[strBytes.Length + sizeof(int)];
+				// TODO:  Need to make custom string serialization to binary
+				Buffer.BlockCopy(BitConverter.GetBytes(strBytes.Length), 0, bytes, 0, sizeof(int));
+				if (strBytes.Length > 0)
+					Buffer.BlockCopy(strBytes, 0, bytes, sizeof(int), strBytes.Length);
+				return bytes;
+			}
+			else if (type == typeof(Vector))
+			{
+				Vector vec = (Vector)o;
+				byte[] bytes = new byte[sizeof(float) * 3];
+				Buffer.BlockCopy(BitConverter.GetBytes(vec.x), 0, bytes, 0, sizeof(float));
+				Buffer.BlockCopy(BitConverter.GetBytes(vec.y), 0, bytes, sizeof(float), sizeof(float));
+				Buffer.BlockCopy(BitConverter.GetBytes(vec.z), 0, bytes, sizeof(float) * 2, sizeof(float));
+				return bytes;
+			}
+			else if (type == null) //TODO: Check if this causes other issues
+				return new byte[1] { 0 };
+			else if (type == typeof(sbyte))
+			{
+				byte[] bytes = new byte[sizeof(sbyte)];
+				Buffer.BlockCopy(new sbyte[] { (sbyte)o }, 0, bytes, 0, sizeof(sbyte));
+				return bytes;
+			}
+			else if (type == typeof(byte))
+				return new byte[1] { (byte)o };
+			else if (type == typeof(char))
+			{
+				byte[] bytes = new byte[sizeof(char)];
+				Buffer.BlockCopy(new char[] { (char)o }, 0, bytes, 0, sizeof(sbyte));
+				return bytes;
+			}
+			else if (type == typeof(bool))
+				return BitConverter.GetBytes((bool)o);
+			else if (type == typeof(short))
+				return BitConverter.GetBytes((short)o);
+			else if (type == typeof(ushort))
+				return BitConverter.GetBytes((ushort)o);
+			else if (type == typeof(int))
+				return BitConverter.GetBytes((int)o);
+			else if (type == typeof(uint))
+				return BitConverter.GetBytes((uint)o);
+			else if (type == typeof(long))
+				return BitConverter.GetBytes((long)o);
+			else if (type == typeof(ulong))
+				return BitConverter.GetBytes((ulong)o);
+			else if (type == typeof(float))
+				return BitConverter.GetBytes((float)o);
+			else if (type == typeof(double))
+				return BitConverter.GetBytes((double)o);
+			else if (type.IsArray)
+			{
+				byte[] bytes;
+
+				using (MemoryStream stream = new MemoryStream())
+				{
+					using (BinaryWriter writer = new BinaryWriter(stream))
+					{
+						int rank = type.GetArrayRank();
+						Type targetType = type.GetElementType();
+
+						if (targetType != typeof(byte))
+							throw new Exception("Currently only byte arrays can be sent as arrays");
+
+						if (rank > 4)
+							throw new Exception("Currently the system only supports up to 4 dimensions in an array");
+
+						int i, j, k, l;
+
+						// Write each dimension length first
+						int[] lengths = new int[rank];
+						for (i = 0; i < rank; i++)
+						{
+							lengths[i] = ((Array)o).GetLength(i);
+							writer.Write(BitConverter.GetBytes(lengths[i]));
+						}
+
+						switch (rank)
+						{
+							case 1:
+								for (i = 0; i < lengths[0]; i++)
+									writer.Write(GetBytesArray(((Array)o).GetValue(i), targetType));
+								break;
+							case 2:
+								for (i = 0; i < lengths[0]; i++)
+									for (j = 0; j < lengths[1]; j++)
+										writer.Write(GetBytesArray(((Array)o).GetValue(i, j), targetType));
+								break;
+							case 3:
+								for (i = 0; i < lengths[0]; i++)
+									for (j = 0; j < lengths[1]; j++)
+										for (k = 0; k < lengths[2]; k++)
+											writer.Write(GetBytesArray(((Array)o).GetValue(i, j, k), targetType));
+								break;
+							case 4:
+								for (i = 0; i < lengths[0]; i++)
+									for (j = 0; j < lengths[1]; j++)
+										for (k = 0; k < lengths[2]; k++)
+											for (l = 0; l < lengths[3]; l++)
+												writer.Write(GetBytesArray(((Array)o).GetValue(i, j, k, l), targetType));
+								break;
+						}
+						bytes = stream.ToArray();
+					}
+					return bytes;
+				}
+			}
+			else if (type == typeof(BMSByte))
+			{
+				byte[] bytesSize = BitConverter.GetBytes(((BMSByte)o).Size);
+				byte[] bytes = new byte[bytesSize.Length + ((BMSByte)o).Size];
+				Buffer.BlockCopy(((BMSByte)o).byteArr, ((BMSByte)o).StartIndex(), bytes, bytesSize.Length, ((BMSByte)o).Size);
+				return bytes;
+			}
+			else if (type.IsEnum)
+				return GetBytesArray(o, Enum.GetUnderlyingType(type));
+			else
+			{
+				// TODO:  Make this a more appropriate exception
+				throw new BaseNetworkException("The type " + type.ToString() + " is not allowed to be sent over the Network (yet)");
+			}
+		}
+
 		/// <summary>
 		/// Creates a BMSByte using ObjectMapper
 		/// </summary>

--- a/BeardedManStudios/Source/Forge/Networking/ObjectMapper.cs
+++ b/BeardedManStudios/Source/Forge/Networking/ObjectMapper.cs
@@ -379,19 +379,11 @@ namespace BeardedManStudios.Forge.Networking
 			else if (type == null) //TODO: Check if this causes other issues
 				return new byte[1] { 0 };
 			else if (type == typeof(sbyte))
-			{
-				byte[] bytes = new byte[sizeof(sbyte)];
-				Buffer.BlockCopy(new sbyte[] { (sbyte)o }, 0, bytes, 0, sizeof(sbyte));
-				return bytes;
-			}
+				return new byte[1] {(byte) ((sbyte)o) };
 			else if (type == typeof(byte))
 				return new byte[1] { (byte)o };
 			else if (type == typeof(char))
-			{
-				byte[] bytes = new byte[sizeof(char)];
-				Buffer.BlockCopy(new char[] { (char)o }, 0, bytes, 0, sizeof(sbyte));
-				return bytes;
-			}
+				return new byte[1] { (byte)((char)o) };
 			else if (type == typeof(bool))
 				return BitConverter.GetBytes((bool)o);
 			else if (type == typeof(short))

--- a/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
+++ b/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
@@ -1164,22 +1164,15 @@ namespace BeardedManStudios.Forge.Networking
 					return;
 				}
 			}
-
-			BMSByte data = new BMSByte();
-
-			// Map the id of the object into the data so that the program knows what fire from
-			ObjectMapper.Instance.MapBytes(data, NetworkId);
-
-			// Map the id of the Rpc as the second data into the byte array
-			ObjectMapper.Instance.MapBytes(data, methodId);
-
+			
 			// Map the behavior flags to the rpc
 			byte behaviorFlags = 0;
 			behaviorFlags |= replacePrevious ? RPC_BEHAVIOR_OVERWRITE : (byte)0;
-			ObjectMapper.Instance.MapBytes(data, behaviorFlags);
 
+			// Map the id of the object into the data so that the program knows what fire from
+			// Map the id of the Rpc as the second data into the byte array
 			// Map all of the data to bytes
-			ObjectMapper.Instance.MapBytes(data, args);
+			BMSByte data = ObjectMapper.BMSByte(NetworkId, methodId, behaviorFlags, args);
 
 			if (Networker is IServer)
 			{

--- a/UnitTests/Source/BMSByteTests.cs
+++ b/UnitTests/Source/BMSByteTests.cs
@@ -1,10 +1,20 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using BeardedManStudios;
+using BeardedManStudios.Forge.Networking;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace UnitTests
+namespace BeardedManStudios.Tests
 {
-	[TestClass]
-	public class BMSByteTests : BaseTest
+	[TestClass()]
+	public class BMSByteTests
 	{
-
+		[TestMethod()]
+		public void BMSByteTest()
+		{
+			byte b = 1;
+			for (int i = 0; i < 10000; i++)
+			{
+				BMSByte data = ObjectMapper.BMSByte(b, b, b, b, b, b, b, b, b, b, b);
+			}
+		}
 	}
 }

--- a/UnitTests/Source/ObjectMapperTests.cs
+++ b/UnitTests/Source/ObjectMapperTests.cs
@@ -13,33 +13,24 @@ namespace UnitTests
 		{
 			System.Diagnostics.Stopwatch watch = new System.Diagnostics.Stopwatch();
 			watch.Start();
-			BMSByte data = new BMSByte();
-			Write(data);
-			Read(data);
+			for (int i = 1; i < 10000; i++)
+			{
+				BMSByte data = new BMSByte();
+				Write(data);
+				Read(data);
+			}
 			watch.Stop();
 			Debug.WriteLine(watch.ElapsedMilliseconds.ToString());
 		}
 
 		public void Write(BMSByte data)
 		{
-			ObjectMapper.Instance.MapBytes(data, (sbyte)1);
-			ObjectMapper.Instance.MapBytes(data, (byte)2);
-			ObjectMapper.Instance.MapBytes(data, (short)3);
-			ObjectMapper.Instance.MapBytes(data, (ushort)4);
-			ObjectMapper.Instance.MapBytes(data, (int)5);
-			ObjectMapper.Instance.MapBytes(data, (uint)6);
-			ObjectMapper.Instance.MapBytes(data, (long)7);
-			ObjectMapper.Instance.MapBytes(data, (ulong)8);
-			ObjectMapper.Instance.MapBytes(data, (float)9.93f);
-			ObjectMapper.Instance.MapBytes(data, (double)99.369);
-			ObjectMapper.Instance.MapBytes(data, 'F');
-			ObjectMapper.Instance.MapBytes(data, "Forge Networking");
-
 			byte[] tmp = new byte[11];
 			for (byte i = 10; i < 21; i++)
 				tmp[i - 10] = i;
 
-			ObjectMapper.Instance.MapBytes(data, tmp);
+			ObjectMapper.Instance.MapBytes(data, (sbyte)1, (byte)2, (short)3, (ushort)4, (int)5,
+			(uint)6, (long)7, (ulong)8, (float)9.93f, (double)99.369, 'F', "Forge Networking", tmp);
 		}
 
 		public void Read(BMSByte data)

--- a/UnitTests/Source/ObjectMapperTests.cs
+++ b/UnitTests/Source/ObjectMapperTests.cs
@@ -1,6 +1,7 @@
 ﻿using BeardedManStudios;
 using BeardedManStudios.Forge.Networking;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
 
 namespace UnitTests
 {
@@ -10,9 +11,13 @@ namespace UnitTests
 		[TestMethod]
 		public void TestObjectMapper()
 		{
+			System.Diagnostics.Stopwatch watch = new System.Diagnostics.Stopwatch();
+			watch.Start();
 			BMSByte data = new BMSByte();
 			Write(data);
 			Read(data);
+			watch.Stop();
+			Debug.WriteLine(watch.ElapsedMilliseconds.ToString());
 		}
 
 		public void Write(BMSByte data)

--- a/UnitTests/Source/ObjectMapperTests.cs
+++ b/UnitTests/Source/ObjectMapperTests.cs
@@ -12,14 +12,15 @@ namespace UnitTests
 		public void TestObjectMapper()
 		{
 			System.Diagnostics.Stopwatch watch = new System.Diagnostics.Stopwatch();
+			BMSByte data = new BMSByte();
 			watch.Start();
-			for (int i = 1; i < 10000; i++)
+			for (int i = 1; i < 100000; i++)
 			{
-				BMSByte data = new BMSByte();
+				data = new BMSByte();
 				Write(data);
-				Read(data);
 			}
 			watch.Stop();
+			Read(data);
 			Debug.WriteLine(watch.ElapsedMilliseconds.ToString());
 		}
 


### PR DESCRIPTION
Instead of mapping/appending every object to a BMSByte (which causes a lot of Resize calls):
1. All of them are converted to byte[] using GetBytesArray
2. Then they are stored in byte[][]
3. Then whole byte[][] is appended to BMSByte which resize only once
+-20% faster depending how much objects are added at once