### PR TITLE
docs: fix movement vector in examples

### DIFF
--- a/docs/mkdocs/docs/GettingStarted/basic-instantiation-example.md
+++ b/docs/mkdocs/docs/GettingStarted/basic-instantiation-example.md
@@ -73,14 +73,14 @@ public class PlayerCube : PlayerCubeBehavior
 			transform.position = networkObject.position;
 
 			// Assign the rotation of this cube to the rotation sent on the network
-			transform.rotation = networkObject.rotation; |
+			transform.rotation = networkObject.rotation;
 
 			// Stop the function here and don't run any more code in this function
 			return;
 		}
 
 		// Get the movement based on the axis input values
-		Vector3 translation = new Vector3(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"), 0);
+		Vector3 translation = new Vector3(Input.GetAxis("Horizontal"), 0, Input.GetAxis("Vertical")).normalized;
 
 		// Scale the speed to normalize for processors
 		translation *= speed * Time.deltaTime;

--- a/docs/mkdocs/docs/GettingStarted/basic-moving-cube-example.md
+++ b/docs/mkdocs/docs/GettingStarted/basic-moving-cube-example.md
@@ -62,7 +62,7 @@ public class BasicCube : BasicCubeBehavior
 	/// Horizontal or Vertical mapped key
 	/// </summary>
 	public float speed = 5.0f;
-	
+
 	private void Update()
 	{
 		// If we are not the owner of this network object then we should
@@ -73,10 +73,10 @@ public class BasicCube : BasicCubeBehavior
 			transform.rotation = networkObject.rotation;
 			return;
 		}
-		
+
 		// Let the owner move the cube around with the arrow keys
-		transform.position += new Vector3(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"), 0.0f) * speed * Time.deltaTime;
-		
+		transform.position += new Vector3(Input.GetAxis("Horizontal") 0, Input.GetAxis("Vertical")).normalized * speed * Time.deltaTime;
+
 		// If we are the owner of the object we should send the new position
 		// and rotation across the network for receivers to move to in the above code
 		networkObject.position = transform.position;


### PR DESCRIPTION
Hi,
a few tiny corrections in docs:

- remove mistyped character
- fix movement vector axes - movement in Unity is on `z` axis, not `y`
- normalize movement vector (so moving in a diagonal direction is not faster than direct movement)
  