### PR TITLE
Update sending-rpc-to-a-single-player.md

### DIFF
--- a/docs/mkdocs/docs/NetworkObject/RemoteProcedureCalls/sending-rpc-to-a-single-player.md
+++ b/docs/mkdocs/docs/NetworkObject/RemoteProcedureCalls/sending-rpc-to-a-single-player.md
@@ -18,7 +18,7 @@ if (networker.IsServer)
 
 // ...
 
-private void PlayerAcceptedSetup(NetworkingPlayer newPlayer)
+private void PlayerAcceptedSetup(NetworkingPlayer newPlayer, Networker sender)
 {
     networkObject.SendRpc(newPlayer, RPC_RPC_NAME, args);
 }


### PR DESCRIPTION
Event registration now takes two arguments instead on one