### PR TITLE
Fixed FieldSyncs clean-up to properly clean up before next test class

### DIFF
--- a/UnitTests/Source/NetworkObjects/FieldSyncs.cs
+++ b/UnitTests/Source/NetworkObjects/FieldSyncs.cs
@@ -13,8 +13,6 @@ namespace UnitTests.Source.NetworkObjects
 		[ClassInitialize]
 		public static void CreateServer(TestContext context)
 		{
-			ConnectSetup(objectCreatedCallback: ObjectCreated);
-
 			NetworkObject.Factory = new NetworkObjectFactory();
 		}
 
@@ -24,13 +22,21 @@ namespace UnitTests.Source.NetworkObjects
 			ConnectTeardown(ObjectCreated);
 		}
 
+        [TestInitialize]
+        public void Startup()
+        {
+            ConnectSetup(objectCreatedCallback: ObjectCreated);
+        }
+
 		[TestCleanup]
 		public void Cleanup()
 		{
 			serverObj = null;
 			clientObj = null;
 			otherClientObj = null;
-		}
+
+            ConnectTeardown(ObjectCreated);
+        }
 
 		private void SetTargetFields(TestNetworkObject target)
 		{


### PR DESCRIPTION
Fixes issue # n/a

Changes proposed / reason for pull request:

- All units tests in **NetworkObjectTests** and the first (BlankRpcTest) in **RemoteProcedureCallTests** are failing due to the otherClient field not being cleaned up after **FieldSyncs** tests.
- [ClassCleanup] decorators don't run directly after that class is finished but rather all at once at the end of the test suite because test order isn't guaranteed.
- Therefore, moving the **FieldSyncs** clean up to the [TestCleanup] decorator and the ConnectSetup to [TestInitialize] allows the same unit test logic but allows the remaining unit tests to pass.

Contact me on Discord (Relic) if more info needed.

@BeardedManStudios