### PR TITLE
Added method & unit test for sending Rpcs unreliably

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
+++ b/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
@@ -1172,7 +1172,7 @@ namespace BeardedManStudios.Forge.Networking
 					TargetPlayer = targetPlayer,
 					MethodId = methodId,
 					Receivers = receivers,
-                    /*Reliable = reliable,*/
+                    Reliable = reliable,
 					Args = args
 				});
 

--- a/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
+++ b/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
@@ -298,6 +298,7 @@ namespace BeardedManStudios.Forge.Networking
 			public NetworkingPlayer TargetPlayer;
 			public byte MethodId;
 			public Receivers Receivers;
+            public bool Reliable;
 			public object[] Args;
 
 			public override string ToString()
@@ -864,8 +865,11 @@ namespace BeardedManStudios.Forge.Networking
 			foreach (PendingRpc rpc in pendingClientRegisterRpc)
 				InvokeRpc(rpc.sender, rpc.timestep, rpc.data, rpc.receivers);
 
-			foreach (PendingLocalRPC rpc in pendingLocalRpcs)
-				SendRpc(rpc.TargetPlayer, rpc.MethodId, rpc.Args);
+            foreach (PendingLocalRPC rpc in pendingLocalRpcs)
+                if (rpc.Reliable)
+                    SendRpc(rpc.TargetPlayer, rpc.MethodId, rpc.Args);
+                else
+                    SendRpcUnreliable(rpc.TargetPlayer, rpc.MethodId, rpc.Args);
 
 			pendingClientRegisterRpc.Clear();
 			pendingLocalRpcs.Clear();
@@ -916,7 +920,7 @@ namespace BeardedManStudios.Forge.Networking
 				// then replicate to the correct receivers
 				// Do not read or replicate if the server denies replication
 				if (ServerAllowRpc(methodId, receivers, rpcArgs))
-					SendRpc(null, methodId, overwriteExisting, receivers, sender, args);
+					SendRpc(null, methodId, overwriteExisting, true, receivers, sender, args);
 
 				return;
 			}
@@ -974,7 +978,7 @@ namespace BeardedManStudios.Forge.Networking
 			lock (rpcBuffer)
 			{
 				for (int i = 0; i < count; i++)
-					FinalizeSendRpc(rpcBuffer[i].data, rpcBuffer[i].receivers, rpcBuffer[i].methodId, rpcBuffer[i].timestep, player);
+					FinalizeSendRpc(rpcBuffer[i].data, rpcBuffer[i].receivers, rpcBuffer[i].methodId, rpcBuffer[i].timestep, true, player);
 			}
 		}
 
@@ -993,7 +997,7 @@ namespace BeardedManStudios.Forge.Networking
 			if (!rpcLookup.TryGetValue(methodName, out methodId))
 				throw new Exception("Invalid method name supplied, this method is also obsolete so maybe this is a good time to update to the new non-string based methods");
 
-			SendRpc(null, methodId, false, receivers, Networker.Me, args);
+			SendRpc(null, methodId, false, true, receivers, Networker.Me, args);
 		}
 
 		/// <summary>
@@ -1005,18 +1009,30 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="args">The input arguments for the method call</param>
 		public void SendRpc(byte methodId, Receivers receivers, params object[] args)
 		{
-			SendRpc(null, methodId, false, receivers, Networker.Me, args);
+			SendRpc(null, methodId, false, true, receivers, Networker.Me, args);
 		}
 
-		/// <summary>
-		/// Build the network frame (message) data for this RPC call so that it is properly
-		/// delegated on the network
-		/// </summary>
-		/// <param name="methodName">The name of the RPC to be called</param>
-		/// <param name="receivers">The clients / server to receive the message</param>
-		/// <param name="replacePrevious">If <c>True</c> then the previous call to this method will be replaced with this one</param>
-		/// <param name="args">The input arguments for the method call</param>
-		[Obsolete("Please use the SendRpc that takes the byte id argument instead for better performance")]
+        /// <summary>
+        /// Build the network frame (message) data for this RPC call so that it is properly
+        /// delegated on the network
+        /// </summary>
+        /// <param name="methodId">The id of the RPC to be called</param>
+        /// <param name="receivers">The clients / server to receive the message</param>
+        /// <param name="args">The input arguments for the method call</param>
+        public void SendRpcUnreliable(byte methodId, Receivers receivers, params object[] args)
+        {
+            SendRpc(null, methodId, false, false, receivers, Networker.Me, args);
+        }
+
+        /// <summary>
+        /// Build the network frame (message) data for this RPC call so that it is properly
+        /// delegated on the network
+        /// </summary>
+        /// <param name="methodName">The name of the RPC to be called</param>
+        /// <param name="receivers">The clients / server to receive the message</param>
+        /// <param name="replacePrevious">If <c>True</c> then the previous call to this method will be replaced with this one</param>
+        /// <param name="args">The input arguments for the method call</param>
+        [Obsolete("Please use the SendRpc that takes the byte id argument instead for better performance")]
 		public void SendRpc(string methodName, bool replacePrevious, Receivers receivers, params object[] args)
 		{
 			byte methodId;
@@ -1024,7 +1040,7 @@ namespace BeardedManStudios.Forge.Networking
 			if (!rpcLookup.TryGetValue(methodName, out methodId))
 				throw new Exception("Invalid method name supplied, this method is also obsolete so maybe this is a good time to update to the new non-string based methods");
 
-			SendRpc(null, methodId, replacePrevious, receivers, Networker.Me, args);
+			SendRpc(null, methodId, replacePrevious, true, receivers, Networker.Me, args);
 		}
 
 		/// <summary>
@@ -1037,7 +1053,7 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="args">The input arguments for the method call</param>
 		public void SendRpc(byte methodId, bool replacePrevious, Receivers receivers, params object[] args)
 		{
-			SendRpc(null, methodId, replacePrevious, receivers, Networker.Me, args);
+			SendRpc(null, methodId, replacePrevious, true, receivers, Networker.Me, args);
 		}
 
 		/// <summary>
@@ -1056,7 +1072,7 @@ namespace BeardedManStudios.Forge.Networking
 			if (!rpcLookup.TryGetValue(methodName, out methodId))
 				throw new Exception("Invalid method name supplied, this method is also obsolete so maybe this is a good time to update to the new non-string based methods");
 
-			SendRpc(targetPlayer, methodId, false, receivers, Networker.Me, args);
+			SendRpc(targetPlayer, methodId, false, true, receivers, Networker.Me, args);
 		}
 
 		/// <summary>
@@ -1074,7 +1090,7 @@ namespace BeardedManStudios.Forge.Networking
 			if (!rpcLookup.TryGetValue(methodName, out methodId))
 				throw new Exception("Invalid method name supplied, this method is also obsolete so maybe this is a good time to update to the new non-string based methods");
 
-			SendRpc(targetPlayer, methodId, false, Receivers.Target, Networker.Me, args);
+			SendRpc(targetPlayer, methodId, false, true, Receivers.Target, Networker.Me, args);
 		}
 
 		/// <summary>
@@ -1086,19 +1102,31 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="args">The input arguments for the method call</param>
 		public void SendRpc(NetworkingPlayer targetPlayer, byte methodId, params object[] args)
 		{
-			SendRpc(targetPlayer, methodId, false, Receivers.Target, Networker.Me, args);
+			SendRpc(targetPlayer, methodId, false, true, Receivers.Target, Networker.Me, args);
 		}
 
-		/// <summary>
-		/// Build the network frame (message) data for this RPC call so that it is properly
-		/// delegated on the network
-		/// </summary>
-		/// <param name="targetPlayer">The player that is being sent this RPC from the server</param>
-		/// <param name="methodName">The name of the RPC to be called</param>
-		/// <param name="receivers">The clients / server to receive the message</param>
-		/// <param name="replacePrevious">If <c>True</c> then the previous call to this method will be replaced with this one</param>
-		/// <param name="args">The input arguments for the method call</param>
-		[Obsolete("Please use the SendRpc that takes the byte id argument instead for better performance")]
+        /// <summary>
+        /// Build the network frame (message) data for this RPC call so that it is properly
+        /// delegated on the network
+        /// </summary>
+        /// <param name="targetPlayer">The player that is being sent this RPC from the server</param>
+        /// <param name="methodId">The id of the RPC to be called</param>
+        /// <param name="args">The input arguments for the method call</param>
+        public void SendRpcUnreliable(NetworkingPlayer targetPlayer, byte methodId, params object[] args)
+        {
+            SendRpc(targetPlayer, methodId, false, false, Receivers.Target, Networker.Me, args);
+        }
+
+        /// <summary>
+        /// Build the network frame (message) data for this RPC call so that it is properly
+        /// delegated on the network
+        /// </summary>
+        /// <param name="targetPlayer">The player that is being sent this RPC from the server</param>
+        /// <param name="methodName">The name of the RPC to be called</param>
+        /// <param name="receivers">The clients / server to receive the message</param>
+        /// <param name="replacePrevious">If <c>True</c> then the previous call to this method will be replaced with this one</param>
+        /// <param name="args">The input arguments for the method call</param>
+        [Obsolete("Please use the SendRpc that takes the byte id argument instead for better performance")]
 		public void SendRpc(NetworkingPlayer targetPlayer, string methodName, bool replacePrevious, Receivers receivers, params object[] args)
 		{
 			byte methodId;
@@ -1106,7 +1134,7 @@ namespace BeardedManStudios.Forge.Networking
 			if (!rpcLookup.TryGetValue(methodName, out methodId))
 				throw new Exception("Invalid method name supplied, this method is also obsolete so maybe this is a good time to update to the new non-string based methods");
 
-			SendRpc(targetPlayer, methodId, replacePrevious, receivers, Networker.Me, args);
+			SendRpc(targetPlayer, methodId, replacePrevious, true, receivers, Networker.Me, args);
 		}
 
 		/// <summary>
@@ -1120,7 +1148,7 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="args">The input arguments for the method call</param>
 		public void SendRpc(NetworkingPlayer targetPlayer, bool replacePrevious, byte methodId, params object[] args)
 		{
-			SendRpc(targetPlayer, methodId, replacePrevious, Receivers.Target, Networker.Me, args);
+			SendRpc(targetPlayer, methodId, replacePrevious, true, Receivers.Target, Networker.Me, args);
 		}
 
 		/// <summary>
@@ -1132,7 +1160,7 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="receivers">The clients / server to receive the message</param>
 		/// <param name="args">The input arguments for the method call</param>
 		/// <returns></returns>
-		public void SendRpc(NetworkingPlayer targetPlayer, byte methodId, bool replacePrevious, Receivers receivers, NetworkingPlayer sender, object[] args)
+		public void SendRpc(NetworkingPlayer targetPlayer, byte methodId, bool replacePrevious, bool reliable, Receivers receivers, NetworkingPlayer sender, object[] args)
 		{
 			if (receivers == Receivers.Target && !(Networker is IServer))
 				receivers = Receivers.Server;
@@ -1144,6 +1172,7 @@ namespace BeardedManStudios.Forge.Networking
 					TargetPlayer = targetPlayer,
 					MethodId = methodId,
 					Receivers = receivers,
+                    /*Reliable = reliable,*/
 					Args = args
 				});
 
@@ -1225,7 +1254,7 @@ namespace BeardedManStudios.Forge.Networking
 			}
 
 			if (!Networker.IsServer || receivers != Receivers.Server)
-				FinalizeSendRpc(data, receivers, methodId, timestep, targetPlayer, sender);
+				FinalizeSendRpc(data, receivers, methodId, timestep, reliable, targetPlayer, sender);
 
 			if (Networker is IServer)
 			{
@@ -1248,7 +1277,7 @@ namespace BeardedManStudios.Forge.Networking
 			Rpcs[methodId].Invoke(new RpcArgs(args, new RPCInfo { SendingPlayer = sender, TimeStep = timestep }), sender == Networker.Me);
 		}
 
-		private void FinalizeSendRpc(BMSByte data, Receivers receivers, byte methodId, ulong timestep, NetworkingPlayer targetPlayer = null, NetworkingPlayer sender = null)
+		private void FinalizeSendRpc(BMSByte data, Receivers receivers, byte methodId, ulong timestep, bool reliable, NetworkingPlayer targetPlayer = null, NetworkingPlayer sender = null)
 		{
 			// Generate a binary frame with a router
 			Binary rpcFrame = new Binary(timestep, Networker is TCPClient, data, receivers, MessageGroupIds.GetId("NO_RPC_" + NetworkId + "_" + methodId), Networker is BaseTCP, RouterIds.RPC_ROUTER_ID);
@@ -1259,7 +1288,7 @@ namespace BeardedManStudios.Forge.Networking
 				if (Networker is TCPServer)
 					((TCPServer)Networker).Send(targetPlayer.TcpClientHandle, rpcFrame);
 				else
-					((UDPServer)Networker).Send(targetPlayer, rpcFrame, true);
+					((UDPServer)Networker).Send(targetPlayer, rpcFrame, reliable);
 			}
 			else
 			{
@@ -1268,7 +1297,7 @@ namespace BeardedManStudios.Forge.Networking
 				else if (Networker is TCPClient)
 					((TCPClient)Networker).Send(rpcFrame);
 				else if (Networker is BaseUDP)
-					((BaseUDP)Networker).Send(rpcFrame, true);
+					((BaseUDP)Networker).Send(rpcFrame, reliable);
 			}
 		}
 

--- a/UnitTests/Source/NetworkObjects/RemoteProcedureCallTests.cs
+++ b/UnitTests/Source/NetworkObjects/RemoteProcedureCallTests.cs
@@ -287,6 +287,17 @@ namespace UnitTests.NetworkObjects
         }
 
         [TestMethod]
+        public void UnreliableRpcTest()
+        {
+            SetupClientBehavior();
+            clientObj.SendRpcUnreliable(TestBehavior.RPC_FUNC_BLANK, Receivers.All);
+            WaitFor(() => { return clientBehavior.calledBlank && serverBehavior.calledBlank; });
+            Assert.IsNull(clientBehavior.objectBlank);
+            Assert.IsNull(serverBehavior.objectBlank);
+            Destroy(clientObj);
+        }
+
+        [TestMethod]
         public void CallMulti()
         {
             int count = 100;


### PR DESCRIPTION
Fixes issue # n/a

Changes proposed / reason for pull request

- Added SendRpcUnreliable to allow Rpcs to be sent unreliably
- Made appropriate changes in NetworkObject.cs to reflect this change
- Added a unit test for this

@BeardedManStudios