### PR TITLE
RE #139 Fixes issue with crash on Application Quit due to not shutting down the server

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Multiplayer Menu/MultiplayerMenu.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Multiplayer Menu/MultiplayerMenu.cs
@@ -24,6 +24,7 @@ public class MultiplayerMenu : MonoBehaviour
 	public GameObject networkManager = null;
 	public GameObject[] ToggledButtons;
 	private NetworkManager mgr = null;
+	private NetWorker server;
 
 	private List<Button> _uiButtons = new List<Button>();
 	private bool _matchmaking = false;
@@ -134,8 +135,6 @@ public class MultiplayerMenu : MonoBehaviour
 
 	public void Host()
 	{
-		NetWorker server;
-
 		if (useTCP)
 		{
 			server = new TCPServer(64);
@@ -240,5 +239,7 @@ public class MultiplayerMenu : MonoBehaviour
 	{
 		if (getLocalNetworkConnections)
 			NetWorker.EndSession();
+
+		server.Disconnect(true);
 	}
 }


### PR DESCRIPTION
Called `server.Disconnect(true);` on application quit which stops the application from crashing.