### PR TITLE
docs: updated getting started link to the new endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Git Source Code:
 
 [YouTube Jumpstart Videos](https://www.youtube.com/playlist?list=PLm1w78-UUlMIi5Vfwy6ckJQIQMHMT-QS5)
 
-[Getting Started Docs](http://docs.forgepowered.com/getting-started/)
+[Getting Started Docs](http://docs.forgepowered.com/GettingStarted/getting-started/)
 
 ## Builds
 #### [Nightly Builds Thanks To @TiToMoskito On Discord / Rexima On GitHub](https://fnr.rumstein.eu/)


### PR DESCRIPTION
Incredibly minor change to the README to make it point at the new endpoint.