### PR TITLE
Enable player rejection during OnPlayerGuidAssigned

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
+++ b/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
@@ -940,6 +940,19 @@ namespace BeardedManStudios.Forge.Networking
 		}
 
 		/// <summary>
+		/// A wrapper around calling the playerGuidAssigned event from child classes
+		/// </summary>
+		/// <param name="player">The player which the guid was assigned to</param>
+		/// <param name="rejected">Returns whether the player was rejected during the handling of the event</param>
+		protected void OnPlayerGuidAssigned(NetworkingPlayer player, out bool rejected)
+		{
+			OnPlayerGuidAssigned(player);
+
+			// Return if the player was rejected during the handling of the event.
+			rejected = (player.IsDisconnecting || DisconnectingPlayers.Contains(player) || ForcedDisconnectingPlayers.Contains(player));
+		}
+
+		/// <summary>
 		/// Used to bind to a port then unbind to trigger any operating system firewall requests
 		/// </summary>
 		public static void PingForFirewall(ushort port = 0)

--- a/BeardedManStudios/Source/Forge/Networking/SteamP2PServer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/SteamP2PServer.cs
@@ -552,7 +552,8 @@ namespace BeardedManStudios.Forge.Networking
 				{
 					currentPlayer.InstanceGuid = frame.ToString();
 
-					OnPlayerGuidAssigned(currentPlayer, out bool rejected);
+					bool rejected;
+					OnPlayerGuidAssigned(currentPlayer, out rejected);
 
 					// If the player was rejected during the handling of the playerGuidAssigned event, don't accept them.
 					if (rejected)

--- a/BeardedManStudios/Source/Forge/Networking/SteamP2PServer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/SteamP2PServer.cs
@@ -552,7 +552,11 @@ namespace BeardedManStudios.Forge.Networking
 				{
 					currentPlayer.InstanceGuid = frame.ToString();
 
-					OnPlayerGuidAssigned(currentPlayer);
+					OnPlayerGuidAssigned(currentPlayer, out bool rejected);
+
+					// If the player was rejected during the handling of the playerGuidAssigned event, don't accept them.
+					if (rejected)
+						return;
 
 					// If so, just resend the player id
 					writeBuffer.Clear();

--- a/BeardedManStudios/Source/Forge/Networking/TCPServer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/TCPServer.cs
@@ -527,7 +527,11 @@ namespace BeardedManStudios.Forge.Networking
 										Text frame = (Text)Factory.DecodeMessage(GetNextBytes(playerStream, available, true), true, MessageGroupIds.TCP_FIND_GROUP_ID, Players[i]);
 										Players[i].InstanceGuid = frame.ToString();
 
-										OnPlayerGuidAssigned(Players[i]);
+										OnPlayerGuidAssigned(Players[i], out bool rejected);
+
+										// If the player was rejected during the handling of the playerGuidAssigned event, don't accept them.
+										if (rejected)
+											continue;
 
 										lock (writeBuffer)
 										{

--- a/BeardedManStudios/Source/Forge/Networking/TCPServer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/TCPServer.cs
@@ -527,7 +527,8 @@ namespace BeardedManStudios.Forge.Networking
 										Text frame = (Text)Factory.DecodeMessage(GetNextBytes(playerStream, available, true), true, MessageGroupIds.TCP_FIND_GROUP_ID, Players[i]);
 										Players[i].InstanceGuid = frame.ToString();
 
-										OnPlayerGuidAssigned(Players[i], out bool rejected);
+										bool rejected;
+										OnPlayerGuidAssigned(Players[i], out rejected);
 
 										// If the player was rejected during the handling of the playerGuidAssigned event, don't accept them.
 										if (rejected)

--- a/BeardedManStudios/Source/Forge/Networking/UDPServer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/UDPServer.cs
@@ -493,7 +493,8 @@ namespace BeardedManStudios.Forge.Networking
 				{
 					currentPlayer.InstanceGuid = frame.ToString();
 
-					OnPlayerGuidAssigned(currentPlayer, out bool rejected);
+					bool rejected;
+					OnPlayerGuidAssigned(currentPlayer, out rejected);
 
 					// If the player was rejected during the handling of the playerGuidAssigned event, don't accept them.
 					if (rejected)

--- a/BeardedManStudios/Source/Forge/Networking/UDPServer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/UDPServer.cs
@@ -493,7 +493,11 @@ namespace BeardedManStudios.Forge.Networking
 				{
 					currentPlayer.InstanceGuid = frame.ToString();
 
-					OnPlayerGuidAssigned(currentPlayer);
+					OnPlayerGuidAssigned(currentPlayer, out bool rejected);
+
+					// If the player was rejected during the handling of the playerGuidAssigned event, don't accept them.
+					if (rejected)
+						return;
 
 					// If so, just resend the player id
 					writeBuffer.Clear();


### PR DESCRIPTION
- Added an overload for OnPlayerGuidAssigned to encapsulate checking for if the player was rejected during the handling of the event
- Now SteamP2PServer, TCPServer, and UDPServer will not send any acceptance messages to the client if they were rejected during OnPlayerGuidAssigned handling

This is needed for multiple sockets in order to ensure incoming connections on a secondary socket are from a player connected on the main socket. If a client is rejected when handling OnPlayerGuidAssigned, the server should not accept the client, nor indicate to the client that they were accepted.