### PR TITLE
Steamworks.dll references toggleable by preprocessor symbol

### DIFF
--- a/BeardedManStudios/BeardedManStudios.csproj
+++ b/BeardedManStudios/BeardedManStudios.csproj
@@ -11,7 +11,8 @@
     <AssemblyName>BeardedManStudios</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,9 +42,10 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>4</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Steamworks.NET">
+    <Reference Include="Steamworks.NET" Condition="$(DefineConstants.Contains('STEAMWORKS'))">
       <HintPath>..\SteamworksDOTNet\Steamworks.NET.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/BeardedManStudios/Source/Forge/DataStore/Cache.cs
+++ b/BeardedManStudios/Source/Forge/DataStore/Cache.cs
@@ -241,24 +241,29 @@ namespace BeardedManStudios.Forge.Networking.DataStore
 
 			Binary sendFrame = new Binary(Socket.Time.Timestep, Socket is TCPClient, data, Receivers.Server, MessageGroupIds.CACHE, Socket is BaseTCP);
 
+#if STEAMWORKS
             if (Socket is SteamP2PClient)
                 ((SteamP2PClient)Socket).Send(sendFrame, true);
             else if (Socket is BaseTCP)
-				((TCPClient)Socket).Send(sendFrame);
+#else
+            if (Socket is BaseTCP)
+#endif
+                ((TCPClient)Socket).Send(sendFrame);
 			else
 				((UDPClient)Socket).Send(sendFrame, true);
 
 			responseHookIncrementer++;
 		}
 
-		/// <summary>
-		/// Inserts a NEW key/value into cache
-		/// </summary>
-		/// <typeparam name="T">The serializable type of object</typeparam>
-		/// <param name="key">The name variable used for storing the specified object</param>
-		/// <param name="value">The object that is to be stored into cache</param>
-		/// <returns>True if successful insert or False if the key already exists</returns>
-		public bool Insert<T>(string key, T value)
+
+        /// <summary>
+        /// Inserts a NEW key/value into cache
+        /// </summary>
+        /// <typeparam name="T">The serializable type of object</typeparam>
+        /// <param name="key">The name variable used for storing the specified object</param>
+        /// <param name="value">The object that is to be stored into cache</param>
+        /// <returns>True if successful insert or False if the key already exists</returns>
+        public bool Insert<T>(string key, T value)
 		{
 			return Insert(key, value, maxDateTime);
 		}

--- a/BeardedManStudios/Source/Forge/Networking/BaseSteamP2P.cs
+++ b/BeardedManStudios/Source/Forge/Networking/BaseSteamP2P.cs
@@ -17,6 +17,7 @@
 |                                                              |
 \------------------------------+------------------------------*/
 
+#if STEAMWORKS
 using BeardedManStudios.Forge.Networking.Frame;
 using Steamworks;
 using System;
@@ -151,3 +152,4 @@ namespace BeardedManStudios.Forge.Networking
 		}
 	}
 }
+#endif

--- a/BeardedManStudios/Source/Forge/Networking/CachedSteamP2PClient.cs
+++ b/BeardedManStudios/Source/Forge/Networking/CachedSteamP2PClient.cs
@@ -36,6 +36,7 @@
 
 #if !UNITY_WEBGL
 #if !NetFX_CORE
+#if STEAMWORKS
 
 using Steamworks;
 using System;
@@ -52,7 +53,7 @@ namespace BeardedManStudios.Forge.Networking
 		private bool active = false;
         private CSteamID steamEndPoint;
 
-        #region Instantiation
+#region Instantiation
         public CachedSteamP2PClient()
 		{
             //steamendpoint = self
@@ -64,14 +65,14 @@ namespace BeardedManStudios.Forge.Networking
             recBuffer.SetSize(65536);
         }
 
-        #endregion
-        #region Close
+#endregion
+#region Close
         public void Close()
 		{
 			((IDisposable)this).Dispose();
 		}
-		#endregion
-		#region Data I/O
+#endregion
+#region Data I/O
 		private BMSByte recBuffer = new BMSByte();
 		private Dictionary<EndPoint, string> connections = new Dictionary<EndPoint, string>();
 		public BMSByte Receive(uint msgSize, out CSteamID from)
@@ -134,17 +135,17 @@ namespace BeardedManStudios.Forge.Networking
 
 			return newArray;
 		}
-		#endregion
+#endregion
 
-		#region Properties
+#region Properties
 		protected bool Active
 		{
 			get { return active; }
 			set { active = value; }
 		}
 
-		#endregion
-		#region Disposing
+#endregion
+#region Disposing
 		void IDisposable.Dispose()
 		{
 			Dispose(true);
@@ -177,7 +178,7 @@ namespace BeardedManStudios.Forge.Networking
 			if (disposed)
 				throw new ObjectDisposedException(GetType().FullName);
 		}
-		#endregion
+#endregion
 
 #if Net_4_5
 
@@ -213,5 +214,6 @@ return d.Item5.BeginSend (d.Item1, d.Item2, d.Item3, d.Item4, callback, null);
 	}
 }
 
+#endif
 #endif
 #endif

--- a/BeardedManStudios/Source/Forge/Networking/NetworkingPlayer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/NetworkingPlayer.cs
@@ -19,7 +19,9 @@
 
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Threading;
+#if STEAMWORKS
 using Steamworks;
+#endif
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -175,18 +177,20 @@ namespace BeardedManStudios.Forge.Networking
 
 		public ulong UniqueReliableMessageIdCounter { get; private set; }
 
+#if STEAMWORKS
         /// <summary>
         /// This is used for steam networking API calls;
         /// this is the steam ID of this networked player.
         /// </summary>
         public CSteamID SteamID { get; protected set; }
 
-        private Queue<ulong> reliableComposersToRemove = new Queue<ulong>();
-
         public void AssignOwnSteamId()
         {
             SteamID = SteamUser.GetSteamID();
         }
+#endif
+
+        private Queue<ulong> reliableComposersToRemove = new Queue<ulong>();
 
         /// <summary>
         /// Constructor for the NetworkingPlayer
@@ -244,6 +248,7 @@ namespace BeardedManStudios.Forge.Networking
 			}
 		}
 
+#if STEAMWORKS
         public NetworkingPlayer(uint networkId, CSteamID steamId, bool isHost, NetWorker networker)
         {
             SteamID = steamId;
@@ -254,6 +259,7 @@ namespace BeardedManStudios.Forge.Networking
             TimeoutMilliseconds = PLAYER_TIMEOUT_DISCONNECT;
             PingInterval = DEFAULT_PING_INTERVAL;
         }
+#endif
 
         public void AssignPort(ushort port)
 		{

--- a/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
+++ b/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
@@ -387,9 +387,13 @@ namespace BeardedManStudios.Forge.Networking
 				NetWorker.BaseNetworkEvent request = (NetWorker sender) =>
 				{
                     // Send the message to the server
+#if STEAMWORKS
                     if (sender is SteamP2PClient)
                         ((SteamP2PClient)sender).Send(createRequest, true);
                     else if (sender is UDPClient)
+#else
+                    if (sender is UDPClient)
+#endif
                         ((UDPClient)sender).Send(createRequest, true);
                     else
                         ((TCPClient)sender).Send(createRequest);
@@ -440,9 +444,13 @@ namespace BeardedManStudios.Forge.Networking
 				Binary createObject = CreateObjectOnServer(frame.Sender, hash);
 
                 // Send the message back to the sending client so that it can finish setting up the network object
-                if (networker is SteamP2PServer)
-                    ((SteamP2PServer)networker).Send(frame.Sender, createObject, true);
-                else if (networker is UDPServer)
+#if STEAMWORKS
+                    if (networker is SteamP2PServer)
+                        ((SteamP2PServer)networker).Send(frame.Sender, createObject, true);
+                    else if (networker is UDPServer)
+#else
+                if (networker is UDPServer)
+#endif
                     ((UDPServer)networker).Send(frame.Sender, createObject, true);
                 else
                     ((TCPServer)networker).Send(frame.Sender.TcpClientHandle, createObject);
@@ -640,9 +648,13 @@ namespace BeardedManStudios.Forge.Networking
 				return createObject;
 
             // If there is a target hash, we are just generating the create object frame
+#if STEAMWORKS
             if (Networker is SteamP2PServer)
                 ((SteamP2PServer)Networker).Send(createObject, true, skipPlayer);
             else if (Networker is UDPServer)
+#else
+            if (Networker is UDPServer)
+#endif
                 ((UDPServer)Networker).Send(createObject, true, skipPlayer);
             else
                 ((TCPServer)Networker).SendAll(createObject, skipPlayer);
@@ -695,10 +707,14 @@ namespace BeardedManStudios.Forge.Networking
 					{
 						Binary targetCreateObject = new Binary(timestep, false, targetData, Receivers.Target, MessageGroupIds.CREATE_NETWORK_OBJECT_REQUEST, networker is BaseTCP, RouterIds.ACCEPT_MULTI_ROUTER_ID);
 
-                        if(networker is SteamP2PServer)
+#if STEAMWORKS
+                        if (networker is SteamP2PServer)
                             ((SteamP2PServer)networker).Send(player, targetCreateObject, true);
                         else if (networker is UDPServer)
-							((UDPServer)networker).Send(player, targetCreateObject, true);
+#else
+                        if (networker is UDPServer)
+#endif
+                            ((UDPServer)networker).Send(player, targetCreateObject, true);
 						else
 							((TCPServer)networker).Send(player.TcpClientHandle, targetCreateObject);
 					}
@@ -1293,18 +1309,26 @@ namespace BeardedManStudios.Forge.Networking
 
 			if (targetPlayer != null && Networker is IServer)
 			{
+#if STEAMWORKS
                 if (Networker is SteamP2PServer)
                     ((SteamP2PServer)Networker).Send(targetPlayer, rpcFrame, reliable);
                 else if (Networker is TCPServer)
+#else
+                if (Networker is TCPServer)
+#endif
                     ((TCPServer)Networker).Send(targetPlayer.TcpClientHandle, rpcFrame);
                 else
                     ((UDPServer)Networker).Send(targetPlayer, rpcFrame, reliable);
             }
 			else
-			{
+            {
+#if STEAMWORKS
                 if (Networker is BaseSteamP2P)
                     ((BaseSteamP2P)Networker).Send(rpcFrame, reliable);
                 else if (Networker is TCPServer)
+#else
+                if (Networker is TCPServer)
+#endif
                     ((TCPServer)Networker).SendAll(rpcFrame);
                 else if (Networker is TCPClient)
                     ((TCPClient)Networker).Send(rpcFrame);
@@ -1342,11 +1366,15 @@ namespace BeardedManStudios.Forge.Networking
 				// Generate a binary frame with a router
 				Binary frame = new Binary(Networker.Time.Timestep, Networker is TCPClient, sendBinaryData, receivers, MessageGroupIds.GetId("NO_BIN_DATA_" + NetworkId), Networker is BaseTCP, RouterIds.BINARY_DATA_ROUTER_ID);
 
+#if STEAMWORKS
                 if (Networker is SteamP2PServer)
                     ((SteamP2PServer)Networker).Send(frame, reliable, skipPlayer);
                 else if (Networker is SteamP2PClient)
                     ((SteamP2PClient)Networker).Send(frame, reliable);
                 else if (Networker is TCPServer)
+#else
+                if (Networker is TCPServer)
+#endif
                     ((TCPServer)Networker).SendAll(frame, skipPlayer);
                 else if (Networker is TCPClient)
                     ((TCPClient)Networker).Send(frame);

--- a/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
+++ b/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
@@ -445,9 +445,9 @@ namespace BeardedManStudios.Forge.Networking
 
                 // Send the message back to the sending client so that it can finish setting up the network object
 #if STEAMWORKS
-                    if (networker is SteamP2PServer)
-                        ((SteamP2PServer)networker).Send(frame.Sender, createObject, true);
-                    else if (networker is UDPServer)
+                if (networker is SteamP2PServer)
+                    ((SteamP2PServer)networker).Send(frame.Sender, createObject, true);
+                else if (networker is UDPServer)
 #else
                 if (networker is UDPServer)
 #endif

--- a/BeardedManStudios/Source/Forge/Networking/SteamNetworkingPlayer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/SteamNetworkingPlayer.cs
@@ -17,6 +17,7 @@
 |                                                              |
 \------------------------------+------------------------------*/
 
+#if STEAMWORKS
 using Steamworks;
 
 namespace BeardedManStudios.Forge.Networking
@@ -32,3 +33,4 @@ namespace BeardedManStudios.Forge.Networking
         }
     }
 }
+#endif

--- a/BeardedManStudios/Source/Forge/Networking/SteamP2PClient.cs
+++ b/BeardedManStudios/Source/Forge/Networking/SteamP2PClient.cs
@@ -17,6 +17,7 @@
 |                                                              |
 \------------------------------+------------------------------*/
 
+#if STEAMWORKS
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Forge.Networking.Nat;
 using BeardedManStudios.Threading;
@@ -410,3 +411,4 @@ namespace BeardedManStudios.Forge.Networking
 		}
 	}
 }
+#endif

--- a/BeardedManStudios/Source/Forge/Networking/SteamP2PPacketComposer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/SteamP2PPacketComposer.cs
@@ -17,6 +17,7 @@
 |                                                              |
 \------------------------------+------------------------------*/
 
+#if STEAMWORKS
 using BeardedManStudios.Forge.Networking.Frame;
 using System;
 using System.Collections.Generic;
@@ -276,3 +277,4 @@ namespace BeardedManStudios.Forge.Networking
 		}
 	}
 }
+#endif

--- a/BeardedManStudios/Source/Forge/Networking/SteamP2PServer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/SteamP2PServer.cs
@@ -17,6 +17,7 @@
 |                                                              |
 \------------------------------+------------------------------*/
 
+#if STEAMWORKS
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Threading;
 using System;
@@ -36,7 +37,7 @@ namespace BeardedManStudios.Forge.Networking
 
 		private SteamNetworkingPlayer currentReadingPlayer = null;
 
-        #region Steamworks API
+#region Steamworks API
         protected Callback<P2PSessionRequest_t> m_CallbackP2PSessionRequest;
         protected Callback<P2PSessionConnectFail_t> m_CallbackP2PSessionConnectFail;
         protected Callback<LobbyCreated_t> m_CallbackLobbyCreated;
@@ -84,7 +85,7 @@ namespace BeardedManStudios.Forge.Networking
                 }
             }
         }
-        #endregion
+#endregion
 
         SteamAPICall_t m_CreateLobbyResult;
 
@@ -626,3 +627,4 @@ namespace BeardedManStudios.Forge.Networking
 		}
 	}
 }
+#endif


### PR DESCRIPTION
Whether the BeardedManStudios project requires Steamworks.dll as a dependency should now be toggleable with the STEAMWORKS conditional compilation symbol in the project settings.

The project compiles both with and without the symbol, and I can confirm the steamless dll will load in unity without the Steamworks.dll present.