### PR TITLE
Fix issue with scene object initialization

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
+++ b/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
@@ -233,10 +233,22 @@ namespace BeardedManStudios.Forge.Networking
 		/// </summary>
 		public event NetworkObject.CreateEvent objectCreateAttach;
 
+
+
 		/// <summary>
 		/// Occurs when a network object has been created on the network
 		/// </summary>
-		public event NetworkObject.NetworkObjectEvent objectCreated;
+		public event NetworkObject.NetworkObjectEvent objectCreated {
+			add {
+				if (_objectCreated == null || !_objectCreated.GetInvocationList().Contains(value))
+					_objectCreated += value;
+			}
+
+			remove {
+				_objectCreated -= value;
+			}
+		}
+		private NetworkObject.NetworkObjectEvent _objectCreated;
 
 		/// <summary>
 		/// TODO: COMMENT
@@ -316,7 +328,7 @@ namespace BeardedManStudios.Forge.Networking
 		/// </summary>
 		public int LatencySimulation { get; set; }
 
-		internal bool ObjectCreatedRegistered { get { return objectCreated != null; } }
+		internal bool ObjectCreatedRegistered { get { return _objectCreated != null; } }
 
 		/// <summary>
 		/// A cached BMSByte to prevent large amounts of garbage collection on packet sequences
@@ -698,8 +710,8 @@ namespace BeardedManStudios.Forge.Networking
 
 		internal void OnObjectCreated(NetworkObject target)
 		{
-			if (objectCreated != null)
-				objectCreated(target);
+			if (_objectCreated != null)
+                _objectCreated(target);
 		}
 
 		internal void OnObjectCreateAttach(int identity, int hash, uint id, FrameStream frame)

--- a/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
+++ b/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
@@ -233,6 +233,7 @@ namespace BeardedManStudios.Forge.Networking
 		public static List<NetworkObject> NetworkObjects { get { return networkObjects; } }
 
 		private static List<NetworkObject> pendingCreates = new List<NetworkObject>();
+		public static readonly object PendingCreatesLock = new object();
 
 		public byte[] Metadata { get; private set; }
 
@@ -728,32 +729,40 @@ namespace BeardedManStudios.Forge.Networking
 
 			if (Networker.PendCreates)
 			{
-				lock (pendingCreates)
+				lock (PendingCreatesLock)
 				{
-					pendingCreates.Add(this);
+                    if (Networker.PendCreates) // Check a second time in case Networker.PendCreates was changed while waiting for the lock
+                    {
+                        pendingCreates.Add(this);
+                        return;
+                    }
 				}
-
-				return;
 			}
 
 			if (onReady != null)
 				onReady(Networker);
 
-			if (pendingBehavior != null)
-			{
-				pendingBehavior.Initialize(this);
+            if (pendingBehavior != null)
+            {
+                pendingBehavior.Initialize(this);
 
-				if (pendingInitialized != null)
-					pendingInitialized(pendingBehavior, this);
-			}
-			else
-				Networker.OnObjectCreated(this);
+                if (pendingInitialized != null)
+                    pendingInitialized(pendingBehavior, this);
+            } else
+                lock (PendingCreatesLock)
+                {
+                    Networker.OnObjectCreated(this);
+                }
 		}
 
-		public static void Flush(NetWorker target)
+		public static void Flush(NetWorker target, List<int> remainingScenesToLoad = null, NetworkObjectEvent objectCreatedHandler = null)
 		{
-			lock (pendingCreates)
+			lock (PendingCreatesLock)
 			{
+                // Ensure the callback is enabled
+                if (objectCreatedHandler != null)
+                    target.objectCreated += objectCreatedHandler;
+
 				for (int i = 0; i < pendingCreates.Count; i++)
 				{
 					if (!target.ObjectCreatedRegistered)
@@ -765,9 +774,9 @@ namespace BeardedManStudios.Forge.Networking
 					target.OnObjectCreated(pendingCreates[i]);
 					pendingCreates.RemoveAt(i--);
 				}
-			}
-
-			target.PendCreates = false;
+                if (remainingScenesToLoad == null || remainingScenesToLoad.Count == 0)
+                    target.PendCreates = false;
+            }
 		}
 
 		/// <summary>

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -630,7 +630,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			foreach (NetworkBehavior behavior in behaviors)
 				pendingObjects.Add(behavior.TempAttachCode, behavior);
 
-			if (pendingNetworkObjects.Count == 0)
+			if (pendingObjects.Count == 0)
 				Networker.objectCreated -= CreatePendingObjects;
 		}
 	}


### PR DESCRIPTION
Re-coded NetworkManager.SceneReady in order to fix clientside scene network behaviour initialization bugs and also reduce or eliminate race conditions.