### PR TITLE
Fixed nested networkObjects issue

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
@@ -32,8 +32,10 @@ namespace BeardedManStudios.Forge.Networking.Generated
 
 			if (!obj.IsOwner)
 			{
-				if (!skipAttachIds.ContainsKey(obj.NetworkId))
-					ProcessOthers(gameObject.transform, obj.NetworkId + 1);
+				if (!skipAttachIds.ContainsKey(obj.NetworkId)){
+					uint newId = obj.NetworkId + 1;
+					ProcessOthers(gameObject.transform, ref newId);
+				}
 				else
 					skipAttachIds.Remove(obj.NetworkId);
 			}

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkBehavior.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkBehavior.cs
@@ -88,7 +88,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 		protected abstract void InitializedTransform();
 
-		protected void ProcessOthers(Transform obj, uint idOffset)
+		protected void ProcessOthers(Transform obj, ref uint idOffset)
 		{
 			int i;
 
@@ -104,7 +104,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			}
 
 			for (i = 0; i < obj.childCount; i++)
-				ProcessOthers(obj.GetChild(i), idOffset);
+				ProcessOthers(obj.GetChild(i), ref idOffset);
 		}
 	}
 }


### PR DESCRIPTION
The nested networkObjects were iterated using an incorrect ID if there was more than one nested networkObjets.
Passing the idOffset parameter as reference updates the id correctly.