### PR TITLE
Fixed wrong NetworkBehavior Components order cause Network Instantiation error

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkManagerTemplate.txt
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkManagerTemplate.txt
@@ -41,7 +41,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 						if (>:[i]:<NetworkObject.Length > 0 && >:[i]:<NetworkObject[obj.CreateCode] != null)
 						{
 							var go = Instantiate(>:[i]:<NetworkObject[obj.CreateCode]);
-							newObj = go.GetComponent<NetworkBehavior>();
+							newObj = go.GetComponent<>:[i]:<Behavior>();
 						}
 					}
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Generated/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Generated/NetworkManager.cs
@@ -42,7 +42,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 						if (ChatManagerNetworkObject.Length > 0 && ChatManagerNetworkObject[obj.CreateCode] != null)
 						{
 							var go = Instantiate(ChatManagerNetworkObject[obj.CreateCode]);
-							newObj = go.GetComponent<NetworkBehavior>();
+							newObj = go.GetComponent<ChatManagerBehavior>();
 						}
 					}
 
@@ -65,7 +65,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 						if (CubeForgeGameNetworkObject.Length > 0 && CubeForgeGameNetworkObject[obj.CreateCode] != null)
 						{
 							var go = Instantiate(CubeForgeGameNetworkObject[obj.CreateCode]);
-							newObj = go.GetComponent<NetworkBehavior>();
+							newObj = go.GetComponent<CubeForgeGameBehavior>();
 						}
 					}
 
@@ -88,7 +88,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 						if (ExampleProximityPlayerNetworkObject.Length > 0 && ExampleProximityPlayerNetworkObject[obj.CreateCode] != null)
 						{
 							var go = Instantiate(ExampleProximityPlayerNetworkObject[obj.CreateCode]);
-							newObj = go.GetComponent<NetworkBehavior>();
+							newObj = go.GetComponent<ExampleProximityPlayerBehavior>();
 						}
 					}
 
@@ -111,7 +111,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 						if (NetworkCameraNetworkObject.Length > 0 && NetworkCameraNetworkObject[obj.CreateCode] != null)
 						{
 							var go = Instantiate(NetworkCameraNetworkObject[obj.CreateCode]);
-							newObj = go.GetComponent<NetworkBehavior>();
+							newObj = go.GetComponent<NetworkCameraBehavior>();
 						}
 					}
 
@@ -134,7 +134,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 						if (TestNetworkObject.Length > 0 && TestNetworkObject[obj.CreateCode] != null)
 						{
 							var go = Instantiate(TestNetworkObject[obj.CreateCode]);
-							newObj = go.GetComponent<NetworkBehavior>();
+							newObj = go.GetComponent<TestBehavior>();
 						}
 					}
 


### PR DESCRIPTION
Prefab used to have to put the  Instantiation NetworkBehviour  Above other NetworkBehviours it, otherwise cause error.
Now, the order of NetworkBehviour doesn't matter.