### PR TITLE
Fixed AssignOwnership

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
+++ b/BeardedManStudios/Source/Forge/Networking/Objects/NetworkObject.cs
@@ -550,15 +550,8 @@ namespace BeardedManStudios.Forge.Networking
 
 		private void AssignOwnership(RpcArgs args)
 		{
-			//call the ownership changed event on old owner
-
-			if (!IsOwner)
-				OwnershipChanged();
-			
-			IsOwner = args.GetNext<bool>();
-          		 //call ownership event on new owner
-			if (!IsOwner)
-				OwnershipChanged();
+		    IsOwner = args.GetNext<bool>();
+		    OwnershipChanged();
 		}
 
 		protected virtual void OwnershipChanged()


### PR DESCRIPTION
**Before merging, check if the "if-statements" are truly redundant.**
Seems the events were called in the wrong order leading the new owner to throw the event while IsOwner was still set to false.
Removed the arbitrary if statements and made sure the bool is set before the callbacks are called.

The if statements seem useless because the server is only sending the Rpc to the correct two players. ( See _"AssignOwnership(NetworkingPlayer targetPlayer)"_)
If however you prefer an extra safety check after receiving the rpc, this code should do the trick:
```cs
            bool tmpOwner = args.GetNext<bool>();
            if (IsOwner != tmpOwner)
            {
                IsOwner = tmpOwner;
                OwnershipChanged();
            }
```