### PR TITLE
Fix logFilePath

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Logging/BMSLogger.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Logging/BMSLogger.cs
@@ -39,7 +39,7 @@ public class BMSLogger : MonoBehaviour, IBMSLogger
 			return;
 
 #if !WINDOWS_UWP && !UNITY_IOS
-		string directory = Application.dataPath + SAVE_FILE_DIRECTORY_NAME;
+		string directory = Application.dataPath + "/" + SAVE_FILE_DIRECTORY_NAME;
 		filepath = directory + SAVE_FILE_NAME;
 		if (!System.IO.Directory.Exists(directory))
 			System.IO.Directory.CreateDirectory(directory);


### PR DESCRIPTION
Add missing `/` between the `Application.DataPath` and `SAVE_FILE_DIRECTORY_NAME` to put the `Logs` directory in the dataPath.