### PR TITLE
Fix capitalisation of connectAttemptFailed event in TCPClientBase to match how it is in UDPClient

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
+++ b/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
@@ -36,7 +36,9 @@ namespace BeardedManStudios.Forge.Networking
         /// </summary>
         private bool disconnectedSelf = false;
 
-        public event BaseNetworkEvent connectAttemptFailed;
+        [Obsolete("This event is obsolete. Use connectAttemptFailed instead.")]
+	public event BaseNetworkEvent ConnectAttemptFailed;
+	public event BaseNetworkEvent connectAttemptFailed;
         byte[] buffer = new byte[8192];
 
         /// <summary>
@@ -55,6 +57,11 @@ namespace BeardedManStudios.Forge.Networking
             }
             catch
             {
+                if (ConnectAttemptFailed != null)
+                {
+                    ConnectAttemptFailed(this);
+                }
+		
                 if (connectAttemptFailed != null)
                 {
                     connectAttemptFailed(this);

--- a/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
+++ b/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
@@ -37,8 +37,8 @@ namespace BeardedManStudios.Forge.Networking
         private bool disconnectedSelf = false;
 
         [Obsolete("This event is obsolete. Use connectAttemptFailed instead.")]
-	public event BaseNetworkEvent ConnectAttemptFailed;
-	public event BaseNetworkEvent connectAttemptFailed;
+	    public event BaseNetworkEvent ConnectAttemptFailed;
+	    public event BaseNetworkEvent connectAttemptFailed;
         byte[] buffer = new byte[8192];
 
         /// <summary>

--- a/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
+++ b/BeardedManStudios/Source/Forge/Networking/TCPClientBase.cs
@@ -36,7 +36,7 @@ namespace BeardedManStudios.Forge.Networking
         /// </summary>
         private bool disconnectedSelf = false;
 
-        public event BaseNetworkEvent ConnectAttemptFailed;
+        public event BaseNetworkEvent connectAttemptFailed;
         byte[] buffer = new byte[8192];
 
         /// <summary>
@@ -55,9 +55,9 @@ namespace BeardedManStudios.Forge.Networking
             }
             catch
             {
-                if (ConnectAttemptFailed != null)
+                if (connectAttemptFailed != null)
                 {
-                    ConnectAttemptFailed(this);
+                    connectAttemptFailed(this);
                 }
                 return;
             }


### PR DESCRIPTION
Make sure that `connectAttemptFailed` uses the same case as other events and matches the `UDPClient`.