### PR TITLE
NCW Improvements to Validation and Logging

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkObjectTemplate.txt
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/NetworkObjectTemplate.txt
@@ -16,6 +16,7 @@ namespace BeardedManStudios.Forge.Networking.Generated
 		public event FieldChangedEvent fieldAltered;
 		#pragma warning restore 0067
 		>:FOREVERY variables:<
+		[ForgeGeneratedField]
 		private >:[0]:< _>:[1]:<;
 		public event FieldEvent<>:[0]:<> >:[1]:<Changed;
 		public >:[3]:< >:[1]:<Interpolation = new >:[3]:<() { LerpT = >:[4]:<, Enabled = >:[2]:< };

--- a/ForgeNetworkingCommon/ForgeNetworkingCommon.csproj
+++ b/ForgeNetworkingCommon/ForgeNetworkingCommon.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Templating\ForgeGeneratedField.cs" />
     <Compile Include="Templating\GeneratedInterpolAttribute.cs" />
     <Compile Include="Templating\GeneratedRPCAttribute.cs" />
     <Compile Include="Templating\GeneratedRPCVariableNamesAttribute.cs" />

--- a/ForgeNetworkingCommon/Templating/ForgeGeneratedField.cs
+++ b/ForgeNetworkingCommon/Templating/ForgeGeneratedField.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace BeardedManStudios.Forge.Networking.Generated
+{
+	[AttributeUsage(AttributeTargets.Field)]
+	public class ForgeGeneratedFieldAttribute : System.Attribute
+	{
+		public ForgeGeneratedFieldAttribute()
+		{
+		}
+	}
+}

--- a/ForgeNetworkingUnityEditor/ForgeClassObject.cs
+++ b/ForgeNetworkingUnityEditor/ForgeClassObject.cs
@@ -92,7 +92,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 
 			MethodInfo[] methods = currentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy).Where(m => m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType.FullName == "BeardedManStudios.Forge.Networking.RpcArgs").ToArray();
 			PropertyInfo[] properties = currentType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
-			FieldInfo[] fields = currentType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+			FieldInfo[] fields = currentType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy).Where(attr => attr.IsDefined(typeof(ForgeGeneratedFieldAttribute), false)).ToArray();
 
 			uniqueMethods.AddRange(methods);
 			uniqueProperties.AddRange(properties);
@@ -191,20 +191,6 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 						uniqueFields.RemoveAt(i--);
 						//TODO: Store the types for re-use
 						continue;
-				}
-
-				if (uniqueFields[i].Name.EndsWith("Changed"))
-				{
-					uniqueFields.RemoveAt(i--);
-					continue;
-				}
-
-				if (uniqueFields[i].Name.EndsWith("Interpolation"))
-				{
-					uniqueFields.RemoveAt(i--);
-
-					//TODO: Store the types for re-use
-					continue;
 				}
 			}
 
@@ -383,7 +369,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 		public static bool HasExactFilename(List<ForgeClassObject> collection, string filename)
 		{
 			bool returnValue = false;
-
+			
 			foreach (ForgeClassObject fo in collection)
 			{
 				if (fo.ExactFilename.ToLower() == filename.ToLower())
@@ -392,7 +378,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 					break;
 				}
 			}
-
+			
 			return returnValue;
 		}
 

--- a/ForgeNetworkingUnityEditor/ForgeClassObject.cs
+++ b/ForgeNetworkingUnityEditor/ForgeClassObject.cs
@@ -216,41 +216,6 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				}
 			}
 
-			#region IGNORES
-			for (int i = 0; i < uniqueFields.Count; ++i)
-			{
-				switch (uniqueFields[i].Name)
-				{
-					case "IDENTITY":
-					case "networkObject":
-					case "fieldAltered":
-					case "_dirtyFields":
-					case "dirtyFields":
-						uniqueFields.RemoveAt(i--);
-						//TODO: Store the types for re-use
-						continue;
-				}
-			}
-
-			for (int i = 0; i < uniqueMethods.Count; ++i)
-			{
-				switch (uniqueMethods[i].Name.ToLower())
-				{
-					case "initialize":
-					case "networkcreateobject":
-						uniqueMethods.RemoveAt(i--);
-						continue;
-				}
-
-				if (uniqueMethods[i].Name.StartsWith("get_") ||
-					uniqueMethods[i].Name.StartsWith("set_"))
-				{
-					uniqueMethods.RemoveAt(i--);
-					continue;
-				}
-			}
-			#endregion
-
 #if FORGE_EDITOR_DEBUGGING
 			forgeClassDebug += "Properties:\n";
 			foreach (PropertyInfo a in uniqueProperties)

--- a/ForgeNetworkingUnityEditor/ForgeClassObject.cs
+++ b/ForgeNetworkingUnityEditor/ForgeClassObject.cs
@@ -90,13 +90,51 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 			if (currentType == null)
 				throw new NullReferenceException("CANNOT PUT SOURCE CODE IN GENERATED FOLDER! PLEASE REMOVE NON GENERATED CODE!");
 
-			MethodInfo[] methods = currentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy).Where(m => m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType.FullName == "BeardedManStudios.Forge.Networking.RpcArgs").ToArray();
+			MethodInfo[] methods = currentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
+				.Where(m => m.GetParameters().Length == 1 && m.GetParameters()[0].ParameterType.FullName == "BeardedManStudios.Forge.Networking.RpcArgs").ToArray();
 			PropertyInfo[] properties = currentType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
-			FieldInfo[] fields = currentType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy).Where(attr => attr.IsDefined(typeof(ForgeGeneratedFieldAttribute), false)).ToArray();
+			FieldInfo[] fields = currentType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
+				.Where(attr => attr.IsDefined(typeof(ForgeGeneratedFieldAttribute), false)).ToArray();
 
 			uniqueMethods.AddRange(methods);
 			uniqueProperties.AddRange(properties);
 			uniqueFields.AddRange(fields);
+
+			//If we don't find any fields containing the attribute, the class is either empty, or using the old format. Try parsing old format
+			if (fields.Length == 0)
+			{
+				FieldInfo[] legacyFields = currentType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+				uniqueFields.AddRange(legacyFields);
+
+				for (int i = 0; i < uniqueFields.Count; ++i)
+				{
+					switch (uniqueFields[i].Name)
+					{
+						case "IDENTITY":
+						case "networkObject":
+						case "fieldAltered":
+						case "_dirtyFields":
+						case "dirtyFields":
+							uniqueFields.RemoveAt(i--);
+							//TODO: Store the types for re-use
+							continue;
+					}
+
+					if (uniqueFields[i].Name.EndsWith("Changed"))
+					{
+						uniqueFields.RemoveAt(i--);
+						continue;
+					}
+
+					if (uniqueFields[i].Name.EndsWith("Interpolation"))
+					{
+						uniqueFields.RemoveAt(i--);
+
+						//TODO: Store the types for re-use
+						continue;
+					}
+				}
+			}
 
 			if (currentType.BaseType != null)
 			{
@@ -202,12 +240,6 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 					case "networkcreateobject":
 						uniqueMethods.RemoveAt(i--);
 						continue;
-				}
-
-				if (uniqueMethods[i].Name.EndsWith("Changed"))
-				{
-					uniqueMethods.RemoveAt(i--);
-					continue;
 				}
 
 				if (uniqueMethods[i].Name.StartsWith("get_") ||

--- a/ForgeNetworkingUnityEditor/ForgeEditorButton.cs
+++ b/ForgeNetworkingUnityEditor/ForgeEditorButton.cs
@@ -333,48 +333,76 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 					result.ReportValidationError(String.Format("Duplicate element \"{0}\" found in \"{1}\"", checkedName, ButtonName));
 				}
 
-                string duplicate = string.Empty;
-                if (checkedName.EndsWith("Changed"))
-                {
-                    duplicate = checkedName.Substring(0, checkedName.LastIndexOf("Changed"));
-                    if (variableNames.Contains(duplicate))
-                    {
-                        result.ReportValidationError(String.Format("Field \"{0}\" conflicts with Changed event of {1}", checkedName, duplicate));
-                    }
-                }
+				switch (ClassVariables[i].FieldName)
+				{
+					case "IDENTITY":
+					case "networkObject":
+					case "fieldAltered":
+					case "_dirtyFields":
+					case "dirtyFields":
+						result.ReportValidationError(String.Format("Field \"{0}\" conflicts with a field name reserved for Forge Networking Remastered", checkedName));
+						break;
+				}
 
-                if (checkedName.EndsWith("Interpolation"))
-                {
-                    duplicate = checkedName.Substring(0, checkedName.LastIndexOf("Interpolation"));
-                    if (variableNames.Contains(duplicate))
-                    {
-                        result.ReportValidationError(String.Format("Field \"{0}\" conflicts with Interpolation field of {1}", checkedName, duplicate));
-                    }
-                }
+				string duplicate = string.Empty;
+				if (checkedName.EndsWith("Changed"))
+				{
+					duplicate = checkedName.Substring(0, checkedName.LastIndexOf("Changed"));
+					if (variableNames.Contains(duplicate))
+					{
+						result.ReportValidationError(String.Format("Field \"{0}\" conflicts with Changed event of {1}", checkedName, duplicate));
+					}
+				}
 
-                //Check if the field name is a valid identifier
-                if (ForgeNetworkingEditor.IsValidName(checkedName))
+				if (checkedName.EndsWith("Interpolation"))
+				{
+					duplicate = checkedName.Substring(0, checkedName.LastIndexOf("Interpolation"));
+					if (variableNames.Contains(duplicate))
+					{
+						result.ReportValidationError(String.Format("Field \"{0}\" conflicts with Interpolation field of {1}", checkedName, duplicate));
+					}
+				}
+
+				//Check if the field name is a valid identifier
+				if (ForgeNetworkingEditor.IsValidName(checkedName))
 					variableNames.Add(checkedName);
 				else
 				{
 					result.ReportValidationError(String.Format("Invalid identifier for Field \"{0}\" in \"{1}\"", checkedName, ButtonName));
 				}
 			}
+
 			//Validate RPCs
 			for (int i = 0; i < RPCVariables.Count; ++i)
 			{
+
 				checkedName = RPCVariables[i].FieldName;
 				if (variableNames.Contains(checkedName))
 				{
 					result.ReportValidationError(String.Format("Duplicate element \"{0}\" found in \"{1}\"", checkedName, ButtonName));
 				}
 
-                //Check if RPC name is a valid identifier
-                if (ForgeNetworkingEditor.IsValidName(checkedName))
-                    variableNames.Add(checkedName);
+				//Check if RPC name is a valid identifier
+				if (ForgeNetworkingEditor.IsValidName(checkedName))
+					variableNames.Add(checkedName);
 				else
 				{
 					result.ReportValidationError(String.Format("Invalid identifier for RPC \"{0}\" in \"{1}\"", checkedName, ButtonName));
+				}
+
+				switch (RPCVariables[i].FieldName.ToLower())
+				{
+					case "initialize":
+					case "networkcreateobject":
+						result.ReportValidationError(String.Format("RPC \"{0}\" conflicts with a method name reserved for Forge Networking Remastered", checkedName));
+						break;
+				}
+
+				if (RPCVariables[i].FieldName.StartsWith("get_") ||
+					RPCVariables[i].FieldName.StartsWith("set_"))
+				{
+					result.ReportValidationError(String.Format("RPC \"{0}\" cannot start with \"get_\" or \"set_\"", checkedName));
+					break;
 				}
 			}
 
@@ -386,9 +414,9 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				{
 					result.ReportValidationError(String.Format("Duplicate element \"{0}\" found in \"{1}\"", checkedName, ButtonName));
 				}
-                //Check if Rewind name is a valid identifier
-                if (ForgeNetworkingEditor.IsValidName(checkedName))
-                    variableNames.Add(checkedName);
+				//Check if Rewind name is a valid identifier
+				if (ForgeNetworkingEditor.IsValidName(checkedName))
+					variableNames.Add(checkedName);
 				else
 				{
 					result.ReportValidationError(String.Format("Invalid identifier for Rewind \"{0}\" in \"{1}\"", checkedName, ButtonName));

--- a/ForgeNetworkingUnityEditor/ForgeEditorButton.cs
+++ b/ForgeNetworkingUnityEditor/ForgeEditorButton.cs
@@ -272,7 +272,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				EditorStyles.boldLabel.alignment = TextAnchor.MiddleCenter;
 
 				if (TiedObject != null)
-					EditorGUILayout.HelpBox("Re-arranging the RPC Arguments will require you to manually update your derriving code to use the new logic, please be aware of this.", MessageType.Warning);
+					EditorGUILayout.HelpBox("Re-arranging the RPC Arguments will require you to manually update your deriving code to use the new logic, please be aware of this.", MessageType.Warning);
 
 				_rpcOrderList.DoLayoutList();
 

--- a/ForgeNetworkingUnityEditor/ForgeEditorButton.cs
+++ b/ForgeNetworkingUnityEditor/ForgeEditorButton.cs
@@ -3,7 +3,6 @@ using System;
 using UnityEngine;
 using UnityEditor;
 using UnityEditorInternal;
-using System.Runtime.Serialization;
 
 namespace BeardedManStudios.Forge.Networking.UnityEditor
 {
@@ -91,7 +90,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 			SetupLists();
 		}
 
-        public ForgeEditorButton(ForgeClassObject fcObj)
+		public ForgeEditorButton(ForgeClassObject fcObj)
 		{
 			_baseType = fcObj.ObjectClassType;
 			TiedObject = fcObj;
@@ -313,89 +312,90 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 			Setup();
 		}
 
-		public bool IsSetupCorrectly()
+		public ValidationResult ValidateSetup()
 		{
-			bool returnValue = true;
-
+			ValidationResult result = new ValidationResult();
 			List<string> variableNames = new List<string>();
 
-			//Make sure it doesn't match the class name
+			//Make sure the class name is valid, and that no fields/RPCs/Rewinds match the class name
 			if (ForgeNetworkingEditor.IsValidName(ButtonName))
 				variableNames.Add(ButtonName);
 			else
-				returnValue = false;
+				result.ReportValidationError(String.Format("Class \"{0}\" has a non-valid name", ButtonName));
 
 			string checkedName = string.Empty;
-			//Check the fields
-			if (returnValue)
+			//Validate Fields
+			for (int i = 0; i < ClassVariables.Count; ++i)
 			{
-				for (int i = 0; i < ClassVariables.Count; ++i)
+				checkedName = ClassVariables[i].FieldName;
+				if (variableNames.Contains(checkedName))
 				{
-					checkedName = ClassVariables[i].FieldName;
-					if (variableNames.Contains(checkedName))
-					{
-						returnValue = false;
-						break;
-					}
+					result.ReportValidationError(String.Format("Duplicate element \"{0}\" found in \"{1}\"", checkedName, ButtonName));
+				}
 
-					if (ForgeNetworkingEditor.IsValidName(checkedName))
-						variableNames.Add(checkedName);
-					else
-					{
-						Debug.LogError("Invalid Character Found");
-						returnValue = false;
-						break;
-					}
+                string duplicate = string.Empty;
+                if (checkedName.EndsWith("Changed"))
+                {
+                    duplicate = checkedName.Substring(0, checkedName.LastIndexOf("Changed"));
+                    if (variableNames.Contains(duplicate))
+                    {
+                        result.ReportValidationError(String.Format("Field \"{0}\" conflicts with Changed event of {1}", checkedName, duplicate));
+                    }
+                }
+
+                if (checkedName.EndsWith("Interpolation"))
+                {
+                    duplicate = checkedName.Substring(0, checkedName.LastIndexOf("Interpolation"));
+                    if (variableNames.Contains(duplicate))
+                    {
+                        result.ReportValidationError(String.Format("Field \"{0}\" conflicts with Interpolation field of {1}", checkedName, duplicate));
+                    }
+                }
+
+                //Check if the field name is a valid identifier
+                if (ForgeNetworkingEditor.IsValidName(checkedName))
+					variableNames.Add(checkedName);
+				else
+				{
+					result.ReportValidationError(String.Format("Invalid identifier for Field \"{0}\" in \"{1}\"", checkedName, ButtonName));
+				}
+			}
+			//Validate RPCs
+			for (int i = 0; i < RPCVariables.Count; ++i)
+			{
+				checkedName = RPCVariables[i].FieldName;
+				if (variableNames.Contains(checkedName))
+				{
+					result.ReportValidationError(String.Format("Duplicate element \"{0}\" found in \"{1}\"", checkedName, ButtonName));
+				}
+
+                //Check if RPC name is a valid identifier
+                if (ForgeNetworkingEditor.IsValidName(checkedName))
+                    variableNames.Add(checkedName);
+				else
+				{
+					result.ReportValidationError(String.Format("Invalid identifier for RPC \"{0}\" in \"{1}\"", checkedName, ButtonName));
 				}
 			}
 
-			//Check the rpcs
-			if (returnValue)
+			//Validate Rewinds
+			for (int i = 0; i < RewindVariables.Count; ++i)
 			{
-				for (int i = 0; i < RPCVariables.Count; ++i)
+				checkedName = RewindVariables[i].FieldName;
+				if (variableNames.Contains(checkedName))
 				{
-					checkedName = RPCVariables[i].FieldName;
-					if (variableNames.Contains(checkedName))
-					{
-						returnValue = false;
-						break;
-					}
-
-					if (ForgeNetworkingEditor.IsValidName(checkedName))
-						variableNames.Add(checkedName);
-					else
-					{
-						Debug.LogError("Invalid Character Found");
-						returnValue = false;
-						break;
-					}
+					result.ReportValidationError(String.Format("Duplicate element \"{0}\" found in \"{1}\"", checkedName, ButtonName));
+				}
+                //Check if Rewind name is a valid identifier
+                if (ForgeNetworkingEditor.IsValidName(checkedName))
+                    variableNames.Add(checkedName);
+				else
+				{
+					result.ReportValidationError(String.Format("Invalid identifier for Rewind \"{0}\" in \"{1}\"", checkedName, ButtonName));
 				}
 			}
 
-			//Check the rewinds
-			if (returnValue)
-			{
-				for (int i = 0; i < RewindVariables.Count; ++i)
-				{
-					checkedName = RewindVariables[i].FieldName;
-					if (variableNames.Contains(checkedName))
-					{
-						returnValue = false;
-						break;
-					}
-
-					if (ForgeNetworkingEditor.IsValidName(checkedName))
-						variableNames.Add(checkedName);
-					else
-					{
-						Debug.LogError("Invalid Character Found");
-						returnValue = false;
-						break;
-					}
-				}
-			}
-
-			return returnValue;
+			return result;
 		}
 
 		private void Setup()
@@ -501,5 +501,5 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				};
 			}
 		}
-    }
+	}
 }

--- a/ForgeNetworkingUnityEditor/ForgeNetworkingEditor.cs
+++ b/ForgeNetworkingUnityEditor/ForgeNetworkingEditor.cs
@@ -1020,12 +1020,11 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				ForgeEditorButton btn = _editorButtons[i];
 				ValidationResult validation = Validate(_editorButtons[i]);
 
-				if (validation.errorMessages.Count > 0)
+				if (!validation.Result)
 				{
 					foreach (string message in validation.errorMessages)
-						Debug.Log(message);
-					Debug.LogException(new ArgumentException(String.Format("{0} failed to compile. Please check compilation output and try again", _editorButtons[i].ButtonName)));
-					throw new Exception("Compilation Failed.");
+						Debug.LogException(new ArgumentException(message));
+					throw new Exception(String.Format("{0} failed to compile. Please check compilation output and try again", _editorButtons[i].ButtonName));
 				}
 
 				if (_editorButtons[i].IsCreated)

--- a/ForgeNetworkingUnityEditor/ForgeNetworkingEditor.cs
+++ b/ForgeNetworkingUnityEditor/ForgeNetworkingEditor.cs
@@ -599,19 +599,9 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				GUI.color = TealBlue;
 			if (GUI.Button(verticleButton, GUIContent.none))
 			{
-				ValidationResult isSetupCorrectly = ActiveButton.ValidateSetup();
-				if (isSetupCorrectly.Result)
-				{
-					_editorButtons.Add(ActiveButton);
-					Compile();
-					ChangeMenu(ForgeEditorActiveMenu.Main);
-				}
-				else
-				{
-					foreach (string error in isSetupCorrectly.errorMessages)
-						Debug.LogError(error);
-					Debug.LogError("Compilation Failed. Please resolve any outputted errors and try again.");
-				}
+				_editorButtons.Add(ActiveButton);
+				Compile();
+				ChangeMenu(ForgeEditorActiveMenu.Main);
 			}
 			GUI.color = Color.white;
 			EditorGUILayout.Space();
@@ -678,20 +668,9 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				GUI.color = TealBlue;
 			if (GUI.Button(verticleButton, GUIContent.none))
 			{
-				ValidationResult isSetupCorrectly = ActiveButton.ValidateSetup();
-				if (isSetupCorrectly.Result)
-				{
-					_editorButtons.Add(ActiveButton);
-					Compile();
-					ChangeMenu(ForgeEditorActiveMenu.Main);
-				}
-				else
-				{
-					foreach (string error in isSetupCorrectly.errorMessages)
-						Debug.LogError(error);
-					Debug.LogError("Compilation Failed. Please resolve any outputted errors and try again.");
-				}
-
+				_editorButtons.Add(ActiveButton);
+				Compile();
+				ChangeMenu(ForgeEditorActiveMenu.Main);
 			}
 			GUI.color = Color.white;
 			EditorGUILayout.Space();
@@ -995,6 +974,14 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 			for (int i = 0; i < _editorButtons.Count; ++i)
 			{
 				ForgeEditorButton btn = _editorButtons[i];
+				ValidationResult validate = btn.ValidateSetup();
+				if(!validate.Result)
+				{
+					foreach (string error in validate.errorMessages)
+						Debug.LogError(error);
+					Debug.LogError(String.Format("Compilation of {0} failed. Please resolve any outputted errors and try again.", btn.ButtonName));
+					break;
+				}
 
 				if (_editorButtons[i].IsCreated)
 				{

--- a/ForgeNetworkingUnityEditor/ForgeNetworkingEditor.cs
+++ b/ForgeNetworkingUnityEditor/ForgeNetworkingEditor.cs
@@ -104,11 +104,11 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 		/// </summary>
 		private ForgeEditorActiveMenu _currentMenu = ForgeEditorActiveMenu.Main;
 
-        private static CodeDomProvider _provider = CodeDomProvider.CreateProvider("C#");
+		private static CodeDomProvider _provider = CodeDomProvider.CreateProvider("C#");
 
-        //COLORS!
-        //Reference to all the cool colors we use!
-        public static Color Gold = new Color(1, 0.8f, 0.6f);
+		//COLORS!
+		//Reference to all the cool colors we use!
+		public static Color Gold = new Color(1, 0.8f, 0.6f);
 		public static Color TealBlue = new Color(0.5f, 0.87f, 1f);
 		public static Color CoolBlue = new Color(0.4f, 0.7f, 1);
 		public static Color LightBlue = new Color(0.6f, 0.8f, 1);
@@ -326,7 +326,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 					ChangeMenu(ForgeEditorActiveMenu.Main);
 				}
 			};
-            AssetDatabase.Refresh();
+			AssetDatabase.Refresh();
 		}
 
 		private Texture2D FlipTexture(Texture2D asset)
@@ -599,20 +599,20 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				GUI.color = TealBlue;
 			if (GUI.Button(verticleButton, GUIContent.none))
 			{
-                ValidationResult isSetupCorrectly = ActiveButton.ValidateSetup();
-                if (isSetupCorrectly.Result)
-                {
-                    _editorButtons.Add(ActiveButton);
-                    Compile();
-                    ChangeMenu(ForgeEditorActiveMenu.Main);
-                }
-                else
-                {
-                    foreach (string error in isSetupCorrectly.errorMessages)
-                        Debug.LogError(error);
-                    Debug.LogError("Compilation Failed. Please resolve any outputted errors and try again.");
-                }
-            }
+				ValidationResult isSetupCorrectly = ActiveButton.ValidateSetup();
+				if (isSetupCorrectly.Result)
+				{
+					_editorButtons.Add(ActiveButton);
+					Compile();
+					ChangeMenu(ForgeEditorActiveMenu.Main);
+				}
+				else
+				{
+					foreach (string error in isSetupCorrectly.errorMessages)
+						Debug.LogError(error);
+					Debug.LogError("Compilation Failed. Please resolve any outputted errors and try again.");
+				}
+			}
 			GUI.color = Color.white;
 			EditorGUILayout.Space();
 			GUILayout.BeginHorizontal();
@@ -678,21 +678,21 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 				GUI.color = TealBlue;
 			if (GUI.Button(verticleButton, GUIContent.none))
 			{
-                ValidationResult isSetupCorrectly = ActiveButton.ValidateSetup();
-                if (isSetupCorrectly.Result)
-                {
-                    _editorButtons.Add(ActiveButton);
-                    Compile();
-                    ChangeMenu(ForgeEditorActiveMenu.Main);
-                }
-                else
-                {
-                    foreach (string error in isSetupCorrectly.errorMessages)
-                        Debug.LogError(error);
-                    Debug.LogError("Compilation Failed. Please resolve any outputted errors and try again.");
-                }
+				ValidationResult isSetupCorrectly = ActiveButton.ValidateSetup();
+				if (isSetupCorrectly.Result)
+				{
+					_editorButtons.Add(ActiveButton);
+					Compile();
+					ChangeMenu(ForgeEditorActiveMenu.Main);
+				}
+				else
+				{
+					foreach (string error in isSetupCorrectly.errorMessages)
+						Debug.LogError(error);
+					Debug.LogError("Compilation Failed. Please resolve any outputted errors and try again.");
+				}
 
-            }
+			}
 			GUI.color = Color.white;
 			EditorGUILayout.Space();
 			GUILayout.BeginHorizontal();
@@ -948,7 +948,6 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 		private void ReloadScripts(string[] files, string[] userFiles)
 		{
 			List<ForgeClassObject> correctFiles = new List<ForgeClassObject>();
-
 			for (int i = 0; i < files.Length; ++i)
 			{
 				if (!files[i].EndsWith(".meta")) //Ignore all meta files
@@ -1082,7 +1081,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 		/// <returns>Whether or not the input is a valid C# identifier</returns>
 		public static bool IsValidName(string identifier)
 		{
-            return _provider.IsValidIdentifier(identifier);
+			return _provider.IsValidIdentifier(identifier);
 		}
 
 		#endregion

--- a/ForgeNetworkingUnityEditor/ForgeNetworkingUnityEditor.csproj
+++ b/ForgeNetworkingUnityEditor/ForgeNetworkingUnityEditor.csproj
@@ -51,6 +51,7 @@
     <Compile Include="IFNSerializable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleJSONEditor.cs" />
+    <Compile Include="ValidationResult.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ForgeNetworkingCommon\ForgeNetworkingCommon.csproj">

--- a/ForgeNetworkingUnityEditor/ValidationResult.cs
+++ b/ForgeNetworkingUnityEditor/ValidationResult.cs
@@ -20,5 +20,14 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 			Result = false;
 			errorMessages.Add(s);
 		}
+
+        ///<summary>
+        ///Package a ValidationResult inside this validation result
+        ///</summary>
+        public void Capture(ValidationResult v)
+        {
+            Result = v.Result && Result;
+            errorMessages.AddRange(v.errorMessages);
+        }
 	}
 }

--- a/ForgeNetworkingUnityEditor/ValidationResult.cs
+++ b/ForgeNetworkingUnityEditor/ValidationResult.cs
@@ -7,14 +7,17 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 {
 	public class ValidationResult
 	{
+		public bool Result { get; private set; }
 		public List<string> errorMessages;
 
 		public ValidationResult()
 		{
+			Result = true;
 			errorMessages = new List<string>();
 		}
 		public void ReportValidationError(string s)
 		{
+			Result = false;
 			errorMessages.Add(s);
 		}
 	}

--- a/ForgeNetworkingUnityEditor/ValidationResult.cs
+++ b/ForgeNetworkingUnityEditor/ValidationResult.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BeardedManStudios.Forge.Networking.UnityEditor
+{
+	public class ValidationResult
+	{
+		public List<string> errorMessages;
+
+		public ValidationResult()
+		{
+			errorMessages = new List<string>();
+		}
+		public void ReportValidationError(string s)
+		{
+			errorMessages.Add(s);
+		}
+	}
+}


### PR DESCRIPTION
Expands validation of fields to the NCW when the user clicks "Save & Compile"

Currently, the NCW populates fields for a given object by using Reflection to retrieve the fields in the class, and performs some filtering based on the name of the field, leaving only the private variables produced by the NCW. This led to issues similar to that described in #152 where fields containing the words "Changed" and "Interpolation" would be produced in the generated code, but on reopening the NCW, these fields would be treated as Changed events or Interpolation variables and be excluded, giving the impression of vanishing variables with no information relayed back to the user as to why this issue was occurring.

This PR modifies this logic to instead have the NCW retrieve fields based on a new attribute, [ForgeGeneratedField], which indicates this field was generated by the NCW, rather than relying on string comparisons. When the user presses the "Save & Compile" button in the NCW to invoke compilation, the previous "isSetupCorrectly" method (now "ValidateSetup") performs validation on the fields/RPCs as it did previously, but now also ensures that no conflict will occur between fields ending in "Changed" or "Interpolation" and the respective auto-generated events and variables. 

The existing validation has also been expanded on to provide more verbose error messages, and the method now returns an object of type ValidationResult which contains a boolean value indicating success or failure to validate, alongside a list of errors which occurred in validation. Previously, the validation step would terminate as soon as a single issue was encountered, but instead the ValidationResult contains all discovered issues, and these are logged to the console on failure.


The isValidName method was also changed, as the Regex expression it matched against was not valid for all cases. It now relies on CodeDomCompiler to validate the identifier is valid.

The new addition of [ForgeGeneratedField] in the NetworkObject template does not affect users, as the original method of finding fields has been preserved for cases where no ForgeGeneratedField attributed fields are found. Combined with the new NetworkObject template, this provides a natural update process on the next compile.