### PR TITLE
Issue 136 - ipparsing not working correctly

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
+++ b/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
@@ -73,6 +73,7 @@ namespace BeardedManStudios.Forge.Networking
 				catch
 				{
 					Logging.BMSLog.Log("Failed to find host");
+					throw new ArgumentException("Unable to resolve host");
 				}
 			}
 

--- a/BeardedManStudios/Source/Forge/Networking/UDPClient.cs
+++ b/BeardedManStudios/Source/Forge/Networking/UDPClient.cs
@@ -147,8 +147,18 @@ namespace BeardedManStudios.Forge.Networking
 				// This is a typical Websockets accept header to be validated
 				byte[] connectHeader = Websockets.ConnectionHeader(headerHash, port);
 
-				// Setup the identity of the server as a player
-				server = new NetworkingPlayer(0, host, true, ResolveHost(host, port), this);
+				try
+				{
+					// Setup the identity of the server as a player
+					server = new NetworkingPlayer(0, host, true, ResolveHost(host, port), this);
+				}
+				catch (ArgumentException)
+				{
+					if (connectAttemptFailed != null)
+						connectAttemptFailed(this);
+
+					throw;
+				}
 
 				// Create the thread that will be listening for new data from connected clients and start its execution
 				Task.Queue(ReadNetwork);

--- a/BeardedManStudios/Source/Forge/Networking/UDPServer.cs
+++ b/BeardedManStudios/Source/Forge/Networking/UDPServer.cs
@@ -568,12 +568,25 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="port">The port number to communicate with the client on</param>
 		private void NatClientConnectAttempt(string host, ushort port)
 		{
-			var x = ResolveHost(host, port);
+			IPEndPoint clientIPEndPoint;
+
 			Logging.BMSLog.LogFormat("ATTEMPTING CONNECT ON {0} AND PORT IS {1}", host, port);
-			Logging.BMSLog.LogFormat("RESOLVED IS {0} AND {1}", x.Address.ToString(), x.Port);
+
+			try
+			{
+				clientIPEndPoint = ResolveHost(host, port);
+			}
+			catch (ArgumentException)
+			{
+				Logging.BMSLog.LogExceptionFormat("Unable to resolve client host {0}", host);
+				// Do nothing as the client's host cannot be resolved.
+				return;
+			}
+
+			Logging.BMSLog.LogFormat("RESOLVED IS {0} AND {1}", clientIPEndPoint.Address.ToString(), clientIPEndPoint.Port);
 
 			// Punch a hole in the nat for this client
-			Client.Send(new byte[1] { 0 }, 1, ResolveHost(host, port));
+			Client.Send(new byte[1] { 0 }, 1, clientIPEndPoint);
 		}
 
 		private void SendBuffer(NetworkingPlayer player)


### PR DESCRIPTION
Fix for issue #136 

In case `Networker.ResolveHost` fails to resolve the provided `host` string then throw an exception and call connectAttemptFailed event handlers for the UDPClient.

Was thinking whether something similar should be added to `UDPServer::NatClientConnectAttempt`? :thinking:  Currently the `return new IPEndPoint(ipAddress, port);` is throwing an `ArgumentNullException` which is not handled there either.


@PHTV#4632