### PR TITLE
Changed FixedUdpate to Update for smooth interpolation.

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -356,7 +356,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			NetWorker.EndSession();
 		}
 
-		private void FixedUpdate()
+		private void Update()
 		{
 			if (Networker != null)
 			{


### PR DESCRIPTION
got jittering when the interpolation is updated in FixedUpdate (fixed timestep: 0.01666667), but jittering got removed after I changed the update from FixedUpdate to Update.

a comment on Discord when I asked about this problem:
[emotitron]: I haven't used forge, but if the interpolation lerp is in fixed... That would definitely be in need of correction.