### PR TITLE
Added support for multiple NICs to LAN discovery feature

### DIFF
--- a/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
+++ b/BeardedManStudios/Source/Forge/Networking/NetWorker.cs
@@ -1093,12 +1093,7 @@ namespace BeardedManStudios.Forge.Networking
 						continue;
 				}
 
-				switch (nic.OperationalStatus) {
-					case OperationalStatus.Up:
-						break;
-					default:
-						continue;
-				}
+				if (nic.OperationalStatus != OperationalStatus.Up) continue;
 
 				foreach (UnicastIPAddressInformation ip in nic.GetIPProperties().UnicastAddresses) {
 					if (ip.Address.AddressFamily == AddressFamily.InterNetwork) {


### PR DESCRIPTION
Fixes Issue
- Machines with multiple active NICs might not be able to find running servers via LAN discovery.
- LAN discovery implementation uses only whatever is the first NIC to search for running servers.

Changes proposed / reason for pull request
- Iterate over all available NICs (limited to WiFi and Ethernet NIC types)
- Search per active NIC per assigned IP for running servers

@BeardedManStudios