### PR TITLE
Make NetworkManager extendable

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -21,11 +21,11 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		public NetWorker MasterServerNetworker { get; private set; }
 		public Dictionary<int, INetworkBehavior> pendingObjects = new Dictionary<int, INetworkBehavior>();
 		public Dictionary<int, NetworkObject> pendingNetworkObjects = new Dictionary<int, NetworkObject>();
-		private string _masterServerHost;
-		private ushort _masterServerPort;
+		protected string _masterServerHost;
+		protected ushort _masterServerPort;
 
-		private List<int> loadedScenes = new List<int>();
-        private List<int> loadingScenes = new List<int>();
+		protected List<int> loadedScenes = new List<int>();
+        protected List<int> loadingScenes = new List<int>();
 
 		public bool IsServer { get { return Networker.IsServer; } }
 
@@ -38,7 +38,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		MVCWebServer.ForgeWebServer webserver = null;
 #endif
 
-		private void Awake()
+		protected virtual void Awake()
 		{
 			if (Instance != null)
 			{
@@ -53,19 +53,19 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			DontDestroyOnLoad(gameObject);
 		}
 
-		private void OnEnable()
+		protected virtual void OnEnable()
 		{
 			if (automaticScenes)
 				SceneManager.sceneLoaded += OnLevelFinishedLoading;
 		}
 
-		private void OnDisable()
+		protected virtual void OnDisable()
 		{
 			if (automaticScenes)
 				SceneManager.sceneLoaded -= OnLevelFinishedLoading;
 		}
 
-		public void Initialize(NetWorker networker, string masterServerHost = "", ushort masterServerPort = 15940, JSONNode masterServerRegisterData = null)
+		public virtual void Initialize(NetWorker networker, string masterServerHost = "", ushort masterServerPort = 15940, JSONNode masterServerRegisterData = null)
 		{
 			Networker = networker;
 			networker.objectCreated += CreatePendingObjects;
@@ -100,7 +100,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			}
 		}
 
-		private void CreatePendingObjects(NetworkObject obj)
+		protected virtual void CreatePendingObjects(NetworkObject obj)
 		{
 			INetworkBehavior behavior;
 
@@ -119,7 +119,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 				Networker.objectCreated -= CreatePendingObjects;
 		}
 
-		public void MatchmakingServersFromMasterServer(string masterServerHost,
+		public virtual void MatchmakingServersFromMasterServer(string masterServerHost,
 			ushort masterServerPort,
 			int elo,
 			System.Action<MasterServerResponse> callback = null,
@@ -210,7 +210,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			}
 		}
 
-		public JSONNode MasterServerRegisterData(NetWorker server, string id, string serverName, string type, string mode, string comment = "", bool useElo = false, int eloRequired = 0)
+		public virtual JSONNode MasterServerRegisterData(NetWorker server, string id, string serverName, string type, string mode, string comment = "", bool useElo = false, int eloRequired = 0)
 		{
 			// Create the get request with the desired filters
 			JSONNode sendData = JSONNode.Parse("{}");
@@ -231,7 +231,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			return sendData;
 		}
 
-		private void RegisterOnMasterServer(JSONNode masterServerData)
+		protected virtual void RegisterOnMasterServer(JSONNode masterServerData)
 		{
 			// The Master Server communicates over TCP
 			TCPMasterClient client = new TCPMasterClient();
@@ -267,14 +267,14 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			MasterServerNetworker = client;
 		}
 
-		private void NetworkerDisconnected(NetWorker sender)
+		protected virtual void NetworkerDisconnected(NetWorker sender)
 		{
 			Networker.disconnected -= NetworkerDisconnected;
 			MasterServerNetworker.Disconnect(false);
 			MasterServerNetworker = null;
 		}
 
-		public void UpdateMasterServerListing(NetWorker server, string comment = null, string gameType = null, string mode = null)
+		public virtual void UpdateMasterServerListing(NetWorker server, string comment = null, string gameType = null, string mode = null)
 		{
 			JSONNode sendData = JSONNode.Parse("{}");
 			JSONClass registerData = new JSONClass();
@@ -290,7 +290,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			UpdateMasterServerListing(sendData);
 		}
 
-		private void UpdateMasterServerListing(JSONNode masterServerData)
+		protected virtual void UpdateMasterServerListing(JSONNode masterServerData)
 		{
 			if (string.IsNullOrEmpty(_masterServerHost))
 			{
@@ -326,7 +326,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			client.Connect(_masterServerHost, _masterServerPort);
 		}
 
-		public void Disconnect()
+		public virtual void Disconnect()
 		{
 #if FN_WEBSERVER
 			webserver.Stop();
@@ -348,7 +348,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			Destroy(gameObject);
 		}
 
-		private void OnApplicationQuit()
+		protected virtual void OnApplicationQuit()
 		{
 			if (Networker != null)
 				Networker.Disconnect(false);
@@ -356,7 +356,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			NetWorker.EndSession();
 		}
 
-		private void Update()
+		protected virtual void Update()
 		{
 			if (Networker != null)
 			{
@@ -365,12 +365,12 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			}
 		}
 
-		private void OnLevelFinishedLoading(Scene scene, LoadSceneMode mode)
+		public virtual void OnLevelFinishedLoading(Scene scene, LoadSceneMode mode)
 		{
 			SceneReady(scene, mode);
 		}
 
-		private void ProcessOthers(Transform obj, NetworkObject createTarget, ref uint idOffset, NetworkBehavior netBehavior = null)
+		protected virtual void ProcessOthers(Transform obj, NetworkObject createTarget, ref uint idOffset, NetworkBehavior netBehavior = null)
 		{
 			int i;
 
@@ -395,7 +395,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 				ProcessOthers(obj.transform.GetChild(i), createTarget, ref idOffset);
 		}
 
-		private void FinalizeInitialization(GameObject go, INetworkBehavior netBehavior, NetworkObject obj, Vector3? position = null, Quaternion? rotation = null, bool sendTransform = true, bool skipOthers = false)
+		protected virtual void FinalizeInitialization(GameObject go, INetworkBehavior netBehavior, NetworkObject obj, Vector3? position = null, Quaternion? rotation = null, bool sendTransform = true, bool skipOthers = false)
 		{
 			if (Networker is IServer)
 				InitializedObject(netBehavior, obj);
@@ -430,7 +430,8 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		/// the currently loaded scene indexes for the client to load
 		/// </summary>
 		/// <param name="player">The player that was just accepted</param>
-		private void PlayerAcceptedSceneSetup(NetworkingPlayer player, NetWorker sender)
+		/// <param name="sender">The sending <see cref="NetWorker"/></param>
+		protected virtual void PlayerAcceptedSceneSetup(NetworkingPlayer player, NetWorker sender)
 		{
 			BMSByte data = ObjectMapper.BMSByte(loadedScenes.Count);
 
@@ -443,7 +444,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			SendFrame(sender, frame, player);
 		}
 
-		private void ReadBinary(NetworkingPlayer player, Binary frame, NetWorker sender)
+		protected virtual void ReadBinary(NetworkingPlayer player, Binary frame, NetWorker sender)
 		{
 			if (frame.GroupId == MessageGroupIds.VIEW_INITIALIZE)
 			{
@@ -564,7 +565,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			}
 		}
 
-		private void SceneReady(Scene scene, LoadSceneMode mode)
+		protected virtual void SceneReady(Scene scene, LoadSceneMode mode)
 		{
 			// If we are loading a completely new scene then we will need
 			// to clear out all the old objects that were stored as they

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -56,13 +56,13 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		protected virtual void OnEnable()
 		{
 			if (automaticScenes)
-				SceneManager.sceneLoaded += OnLevelFinishedLoading;
+				SceneManager.sceneLoaded += SceneReady;
 		}
 
 		protected virtual void OnDisable()
 		{
 			if (automaticScenes)
-				SceneManager.sceneLoaded -= OnLevelFinishedLoading;
+				SceneManager.sceneLoaded -= SceneReady;
 		}
 
 		public virtual void Initialize(NetWorker networker, string masterServerHost = "", ushort masterServerPort = 15940, JSONNode masterServerRegisterData = null)
@@ -365,11 +365,6 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			}
 		}
 
-		public virtual void OnLevelFinishedLoading(Scene scene, LoadSceneMode mode)
-		{
-			SceneReady(scene, mode);
-		}
-
 		protected virtual void ProcessOthers(Transform obj, NetworkObject createTarget, ref uint idOffset, NetworkBehavior netBehavior = null)
 		{
 			int i;
@@ -565,7 +560,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			}
 		}
 
-		protected virtual void SceneReady(Scene scene, LoadSceneMode mode)
+		public virtual void SceneReady(Scene scene, LoadSceneMode mode)
 		{
 			// If we are loading a completely new scene then we will need
 			// to clear out all the old objects that were stored as they


### PR DESCRIPTION
After a conversation on discord in #networking-questions a suggestion came up to make the NetworkManager extensible and allow custom code to override current functionality.

Useful in cases where a user would like to show a loading screen while the game scene is loading, but automatic scenes makes that hard. When it is turned off then there are a few gotchas that they need to be aware of with in scene network objects and their correct initialisation.

Also useful when creating scenebased network managers like the showcased work of @k77torpedo where a server can manage multiple scenes.

Changes in this PR based on the suggestions:
- Change all private variables to protected so deriving classes can access them.
- Change all non-generated private methods protected to deriving classes have access to them.
- Make all non-generated methods virtual so deriving classes can override them.
- Make OnLevelFinishedLoading public so custom code can use it to manage scene loading. See issue #235 by @ambocclusion