### PR TITLE
 Fix BMSByte.GetByteArray

### DIFF
--- a/BeardedManStudios/Source/BMSByte.cs
+++ b/BeardedManStudios/Source/BMSByte.cs
@@ -694,7 +694,7 @@ namespace BeardedManStudios
 				MoveStartIndex(length);
 
 			byte[] data = new byte[length];
-			Buffer.BlockCopy(byteArr, start, data, 0, length);
+			Buffer.BlockCopy(byteArr, start + sizeof(int), data, 0, length);
 			return data;
 		}
 


### PR DESCRIPTION
Old method copied the four bytes of the array length into the start of the array and missed the last four bytes of the array.