### PR TITLE
Allow in scene network managers to work

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -34,6 +34,11 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		/// </summary>
 		public bool automaticScenes = true;
 
+		/// <summary>
+		/// Internal flag to indicate that the Initialize method has been called.
+		/// </summary>
+		protected bool initialized;
+
 #if FN_WEBSERVER
 		MVCWebServer.ForgeWebServer webserver = null;
 #endif
@@ -98,6 +103,8 @@ namespace BeardedManStudios.Forge.Networking.Unity
 				webserver.Start();
 #endif
 			}
+
+			initialized = true;
 		}
 
 		protected virtual void CreatePendingObjects(NetworkObject obj)
@@ -562,6 +569,10 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 		public virtual void SceneReady(Scene scene, LoadSceneMode mode)
 		{
+			// The NetworkManager has not yet been initialized with a Networker.
+			if (!initialized)
+				return;
+
 			// If we are loading a completely new scene then we will need
 			// to clear out all the old objects that were stored as they
 			// are no longer needed


### PR DESCRIPTION
Currently if automatic scenes is turned on on the Network manager then that will trigger as soon as the scene loads with the network manager in it. This causes a null reference exception as the network manager's networker has not been assigned yet via the Initialize method.

The change in this PR adds a flag to indicate whether the Initilaize method has been called or not and will bail out early in the SceneReady method if not preventing the null reference exception.

The reason for this change is questions and suggestions comming up on discord where people would like to keep gameobjects organised. The only reason for a network manager to be a prefab is the automatic scenes functionality attaches the listener in OnEnable. This PR removes this requirement.