### PR TITLE
[BUG] Standalone NetworkBehavior RPC byte ID count missmatch

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/StandAloneNetworkBehaviorTemplate.txt
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/Resources/BMS_Forge_Editor/StandAloneNetworkBehaviorTemplate.txt
@@ -9,7 +9,7 @@ namespace BeardedManStudios.Forge.Networking.Generated
 	public abstract partial class >:className:< : INetworkBehavior
 	{
 		>:FOREVERY constRpcs:<
-		public const byte RPC_>:[0]:< = >:[idx]:< + 5;
+		public const byte RPC_>:[0]:< = >:[idx]:< + 4;
 		>:ENDFOREVERY:<
 		
 		public >:networkObject:< networkObject = null;


### PR DESCRIPTION
Standalone NetworkBehaviors only have 4 default RPCs so new RPC byte id count should start from 4 instead of 5.