### PR TITLE
When generating RPC name constants they should use the invariant cult…

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/ForgeNetworkingEditor.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Editor/ForgeNetworkingEditor.cs
@@ -837,7 +837,7 @@ namespace BeardedManStudios.Forge.Networking.UnityEditor
 					if (constRpc.Length > 0 && caps.Contains(btn.RPCVariables[i].FieldName[j]))
 						constRpc += "_";
 
-					constRpc += btn.RPCVariables[i].FieldName[j].ToString().ToUpper();
+					constRpc += btn.RPCVariables[i].FieldName[j].ToString().ToUpperInvariant();
 				}
 				constRpc = constRpc.Replace("R_P_C_", "");
 


### PR DESCRIPTION
Fix for issue #254 