### PR TITLE
Issue-133 update license header

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Modules/VOIP/VOIP.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Modules/VOIP/VOIP.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|							   - The Forge Team                |
-|								 Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-#if !UNITY_WEBGL && !WINDOWS_UWP
+﻿#if !UNITY_WEBGL && !WINDOWS_UWP
 using BeardedManStudios.Forge.Logging;
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Threading;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/BMSUnityExtensions.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/BMSUnityExtensions.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace BeardedManStudios.Forge.Networking.Unity
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/ArgumentParser.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/ArgumentParser.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace BeardedManStudios
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/BMSByte.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/BMSByte.cs
@@ -1,25 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/BMSExtensions.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/BMSExtensions.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios
+﻿namespace BeardedManStudios
 {
 	public static class BMSExtensions
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/BeardedMath.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/BeardedMath.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios
+﻿namespace BeardedManStudios
 {
 	/// <summary>
 	/// A class that is to be extended to support math models that are not currently available in any 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/DataStore/Cache.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/DataStore/Cache.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using System;
 using System.Collections.Generic;
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Logging/BMSLog.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Logging/BMSLog.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Logging
+﻿namespace BeardedManStudios.Forge.Logging
 {
 	public class BMSLog
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Logging/IBMSLogger.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Logging/IBMSLogger.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Logging
+﻿namespace BeardedManStudios.Forge.Logging
 {
 	public interface IBMSLogger
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/BasePacketComposer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/BasePacketComposer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/BaseSteamP2P.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/BaseSteamP2P.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-#if STEAMWORKS
+﻿#if STEAMWORKS
 using BeardedManStudios.Forge.Networking.Frame;
 using Steamworks;
 using System;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/BaseUDP.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/BaseUDP.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using System;
 using System.Collections.Generic;
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Enums/Receivers.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Enums/Receivers.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	/// <summary>
 	/// This is often used in conjunction with RPC or WriteCustom in order to limit who gets the call

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Exceptions.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Exceptions.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Filters/IConnectionFilter.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Filters/IConnectionFilter.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking.Filters
+﻿namespace BeardedManStudios.Forge.Networking.Filters
 {
     interface IConnectionFilter
     {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Binary.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Binary.cs
@@ -1,24 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-
-namespace BeardedManStudios.Forge.Networking.Frame
+﻿namespace BeardedManStudios.Forge.Networking.Frame
 {
 	public class Binary : FrameStream
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/ConnectionClose.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/ConnectionClose.cs
@@ -1,24 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-
-namespace BeardedManStudios.Forge.Networking.Frame
+﻿namespace BeardedManStudios.Forge.Networking.Frame
 {
 	public class ConnectionClose : FrameStream
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Continuation.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Continuation.cs
@@ -1,24 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-
-namespace BeardedManStudios.Forge.Networking.Frame
+﻿namespace BeardedManStudios.Forge.Networking.Frame
 {
 	public class Continuation : FrameStream
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Error.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Error.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Text;
+﻿using System.Text;
 
 namespace BeardedManStudios.Forge.Networking.Frame
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Factory.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Factory.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/FrameStream.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/FrameStream.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 
 namespace BeardedManStudios.Forge.Networking.Frame
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Ping.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Ping.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking.Frame
+﻿namespace BeardedManStudios.Forge.Networking.Frame
 {
 	public class Ping : FrameStream
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Pong.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Pong.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking.Frame
+﻿namespace BeardedManStudios.Forge.Networking.Frame
 {
 	public class Pong : FrameStream
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Text.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Frame/Text.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Text;
+﻿using System.Text;
 
 namespace BeardedManStudios.Forge.Networking.Frame
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/IClient.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/IClient.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public interface IClient
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/IClientMockPlayer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/IClientMockPlayer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public interface IClientMockPlayer
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/IServer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/IServer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/IUserAuthenticator.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/IUserAuthenticator.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/MasterServerResponse.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/MasterServerResponse.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.SimpleJSON;
+﻿using BeardedManStudios.SimpleJSON;
 using System.Collections.Generic;
 
 namespace BeardedManStudios.Forge.Networking

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Nat/NatHolePunch.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Nat/NatHolePunch.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.SimpleJSON;
 
 namespace BeardedManStudios.Forge.Networking.Nat

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/NetWorker.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/NetWorker.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.DataStore;
+﻿using BeardedManStudios.Forge.Networking.DataStore;
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Source.Forge.Networking;
 using BeardedManStudios.Threading;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/NetworkingPlayer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/NetworkingPlayer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Threading;
 #if STEAMWORKS
 using Steamworks;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/ObjectMapper.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/ObjectMapper.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-#if BMS_DEBUGGING
+﻿#if BMS_DEBUGGING
 #define BMS_DEBUGGING_UNITY
 #endif
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/IInterpolator.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/IInterpolator.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public interface IInterpolator<T>
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/INetworkBehavior.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/INetworkBehavior.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public interface INetworkBehavior
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/INetworkObjectFactory.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/INetworkObjectFactory.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/InterpolateDouble.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/InterpolateDouble.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public struct InterpolateDouble : IInterpolator<double>
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/InterpolateFloat.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/InterpolateFloat.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public struct InterpolateFloat : IInterpolator<float>
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/Interpolated.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/Interpolated.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public struct Interpolated<T> : IInterpolator<T>
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/NetworkObject.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/NetworkObject.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Source.Forge.Networking;
 using BeardedManStudios.Threading;
 using System;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/Rewind.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/Rewind.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace BeardedManStudios.Forge.Networking

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/RPCInfo.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/RPCInfo.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public struct RPCInfo
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Rpc.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Rpc.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Source.Threading;
+﻿using BeardedManStudios.Source.Threading;
 using System;
 using System.Collections.Generic;
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/RpcArgs.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/RpcArgs.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public struct RpcArgs
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/SteamNetworkingPlayer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/SteamNetworkingPlayer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-#if STEAMWORKS
+﻿#if STEAMWORKS
 using Steamworks;
 
 namespace BeardedManStudios.Forge.Networking

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/SteamP2PClient.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/SteamP2PClient.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-#if STEAMWORKS
+﻿#if STEAMWORKS
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Forge.Networking.Nat;
 using BeardedManStudios.Threading;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/SteamP2PPacketComposer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/SteamP2PPacketComposer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-#if STEAMWORKS
+﻿#if STEAMWORKS
 using BeardedManStudios.Forge.Networking.Frame;
 using System;
 using System.Collections.Generic;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/SteamP2PServer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/SteamP2PServer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-#if STEAMWORKS
+﻿#if STEAMWORKS
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Threading;
 using System;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPClientWebsockets.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPClientWebsockets.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using System;
 using System.Runtime.InteropServices;
 

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPMasterClient.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPMasterClient.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 using System.Threading;
 
 namespace BeardedManStudios.Forge.Networking

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPServer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPServer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Threading;
 using System;
 using System.Collections.Generic;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Time.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Time.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Diagnostics;
+﻿using System.Diagnostics;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPClient.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPClient.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Forge.Networking.Nat;
 using BeardedManStudios.Threading;
 using System;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPGroupIds.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPGroupIds.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPNetworkingPlayer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPNetworkingPlayer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public class UDPNetworkingPlayer : NetworkingPlayer
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacket.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacket.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-namespace BeardedManStudios.Forge.Networking
+﻿namespace BeardedManStudios.Forge.Networking
 {
 	public struct UDPPacket
 	{

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacketComposer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacketComposer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Threading;
 using System;
 using System.Collections.Generic;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacketGroup.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacketGroup.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacketManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacketManager.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacketSequence.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPPacketSequence.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace BeardedManStudios.Forge.Networking
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPServer.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPServer.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using BeardedManStudios.Forge.Networking.Frame;
+﻿using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Forge.Networking.Nat;
 using BeardedManStudios.Threading;
 using System;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Websockets.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Websockets.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Threading/IThreadRunner.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Threading/IThreadRunner.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 
 namespace BeardedManStudios.Source.Threading
 {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Threading/Task.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Threading/Task.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 using System.Threading;
 
 namespace BeardedManStudios.Threading

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/UnityObjectMapper.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/UnityObjectMapper.cs
@@ -1,25 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-
-
-using System;
+﻿using System;
 using UnityEngine;
 
 namespace BeardedManStudios.Forge.Networking.Unity

--- a/ForgeNetworkingCommon/Templating/TemplateSystem.cs
+++ b/ForgeNetworkingCommon/Templating/TemplateSystem.cs
@@ -1,23 +1,4 @@
-﻿/*-----------------------------+-------------------------------\
-|                                                              |
-|                         !!!NOTICE!!!                         |
-|                                                              |
-|  These libraries are under heavy development so they are     |
-|  subject to make many changes as development continues.      |
-|  For this reason, the libraries may not be well commented.   |
-|  THANK YOU for supporting forge with all your feedback       |
-|  suggestions, bug reports and comments!                      |
-|                                                              |
-|                              - The Forge Team                |
-|                                Bearded Man Studios, Inc.     |
-|                                                              |
-|  This source code, project files, and associated files are   |
-|  copyrighted by Bearded Man Studios, Inc. (2012-2017) and    |
-|  may not be redistributed without written permission.        |
-|                                                              |
-\------------------------------+------------------------------*/
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;


### PR DESCRIPTION
Removed old license header as the project is now licensed under the MIT License and the license file is in the root of the repository. This should resolve issue #133 