### PR TITLE
Changed the network object registration timing

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/NetWorker.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/NetWorker.cs
@@ -617,10 +617,11 @@ namespace BeardedManStudios.Forge.Networking
 					id = forceId;
 
 					if (!networkObject.RegisterOnce(id))
+					{
 						throw new BaseNetworkException("The supplied network object has already been assigned to a networker and has an id");
+					}
 
-					//AddNetworkObject(forceId, networkObject);
-					//NetworkObjectList.Add(networkObject);
+					CompleteInitialization(networkObject);
 				}
 				else
 				{
@@ -637,8 +638,7 @@ namespace BeardedManStudios.Forge.Networking
 							throw new BaseNetworkException("The supplied network object has already been assigned to a networker and has an id");
 						}
 
-						//AddNetworkObject(currentNetworkObjectId, networkObject);
-						//NetworkObjectList.Add(networkObject);
+						CompleteInitialization(networkObject);
 						break;
 					} while (IsBound);
 				}

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/NetWorker.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/NetWorker.cs
@@ -617,9 +617,7 @@ namespace BeardedManStudios.Forge.Networking
 					id = forceId;
 
 					if (!networkObject.RegisterOnce(id))
-					{
 						throw new BaseNetworkException("The supplied network object has already been assigned to a networker and has an id");
-					}
 
 					CompleteInitialization(networkObject);
 				}


### PR DESCRIPTION
Why pushed this PR?
I had a problem that the client A doesn't get synced a network object of the client B sometimes when they try to connect to a server at the same time.

Sequences when new client connects to a server(AFAIK):
1. A client connects to the server.
2. The server sends the data containing currently existed 'NetworkObjects' to the client.
3. A networkObject is created for the client and send the data to other players.
4. On the main thread, the networkObject is initialized and added to 'NetworkObjects'.

In the case that two clients try to connect at the same time,
sometimes the client connected later than another doesn't get the networkObject data for another client.
There are two clients: A, B.
A3-B1-B2-A4 => a networkObject of the client A doesn't get synced on the client B side, because A4 happens later than B2.

so, to solve these problem, I merged the step 3 and 4 in to one step.

Merged Sequences:
1. A client connects to the server. (same)
2. The server sends the data containing currently existed 'NetworkObjects' to the client. (same)
3. A networkObject is created and initialize & added to 'NetworkObjects'. for the client and send the data to other players.

so, A3-B1-B2 (NetworkObjects is updated at A3 timing, there's no omitted data at B2.)

Please, review this PR and give me any opinons to discuss or questions about this.