### PR TITLE
Issue-203 In scene networkbehaviors error

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -662,10 +662,23 @@ namespace BeardedManStudios.Forge.Networking.Unity
                 {
 	                // Pending network behavior list is not empty when there are no more scenes to load.
 	                // Probably network behaviours that were placed in the scene have already been destroyed on the server and other clients!
+
+	                List<GameObject> objetsToDestroy = new List<GameObject>();
 	                foreach (var kvp in pendingObjects)
 	                {
-		                Destroy(((NetworkBehavior)kvp.Value).gameObject);
+		                var gameObject = ((NetworkBehavior) kvp.Value).gameObject;
+		                if (!objetsToDestroy.Contains(gameObject))
+			                objetsToDestroy.Add(gameObject);
 	                }
+
+	                pendingObjects.Clear();
+
+	                foreach (var o in objetsToDestroy)
+	                {
+		                Destroy(o);
+	                }
+
+	                objetsToDestroy.Clear();
                 }
 
             } else

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/NetworkManager.cs
@@ -621,7 +621,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
                             Networker.objectCreated -= CreatePendingObjects;
                     }
                 }
-                    
+
 
 				return;
 			}
@@ -658,6 +658,15 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
                 if (pendingObjects.Count == 0 && loadingScenes.Count == 0)
                     Networker.objectCreated -= CreatePendingObjects;
+				else if (pendingObjects.Count != 0 && loadingScenes.Count == 0)
+                {
+	                // Pending network behavior list is not empty when there are no more scenes to load.
+	                // Probably network behaviours that were placed in the scene have already been destroyed on the server and other clients!
+	                foreach (var kvp in pendingObjects)
+	                {
+		                Destroy(((NetworkBehavior)kvp.Value).gameObject);
+	                }
+                }
 
             } else
 			{
@@ -679,14 +688,14 @@ namespace BeardedManStudios.Forge.Networking.Unity
                 Debug.LogWarning("Networker is null. Network manager has not been initiliased.");
                 return null;
             }
-			
+
             NetworkObject foundNetworkObject = null;
 			if (!Networker.NetworkObjects.TryGetValue(id, out foundNetworkObject) || foundNetworkObject.AttachedBehavior == null)
             {
                 Debug.LogWarning("No object found by id or object has no attached behavior.");
                 return null;
             }
-			
+
             return ((NetworkBehavior)foundNetworkObject.AttachedBehavior).gameObject;
         }
     }


### PR DESCRIPTION
Fix for issue #203 

When there are network behaviours place in the scene via the editor (not runtime) then are destroyed during runtime will cause late joining clients to no be able to initialize these and result in gameobjects being stuck in the scene.

This fix looks at the `pendingObjects` list when there are no more scenes to load and if it is not empty then it proceeds to Destroy these objects as they were most probably destroyed already on the server and all other clients.