### PR TITLE
Convenience version of SendRpc to send to a list of NetworkingPlayers.

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/NetworkObject.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/Objects/NetworkObject.cs
@@ -179,7 +179,7 @@ namespace BeardedManStudios.Forge.Networking
 		public INetworkBehavior AttachedBehavior { get; set; }
 
 		/// <summary>
-		/// Occurs when the pending behavior supplied has been initialized 
+		/// Occurs when the pending behavior supplied has been initialized
 		/// </summary>
 		public event NetworkBehaviorEvent pendingInitialized;
 
@@ -1116,6 +1116,21 @@ namespace BeardedManStudios.Forge.Networking
 			SendRpc(targetPlayer, methodId, false, true, Receivers.Target, Networker.Me, args);
 		}
 
+		/// <summary>
+		/// Build the network frame (message) data for this RPC call so that it is properly
+		/// delegated on the network
+		/// </summary>
+		/// <param name="targetPlayers">An array of <see cref="NetworkingPlayer"/>s to send this RPC from the server</param>
+		/// <param name="methodId">The id of the RPC to be called</param>
+		/// <param name="args">The input arguments for the method call</param>
+		public void SendRpc(NetworkingPlayer[] targetPlayers, byte methodId, params object[] args)
+		{
+			for (int i = 0; i < targetPlayers.Length; i++)
+			{
+				SendRpc(targetPlayers[i], methodId, false, true, Receivers.Target, Networker.Me, args);
+			}
+		}
+
         /// <summary>
         /// Build the network frame (message) data for this RPC call so that it is properly
         /// delegated on the network
@@ -1209,7 +1224,7 @@ namespace BeardedManStudios.Forge.Networking
 					return;
 				}
 			}
-			
+
 			// Map the behavior flags to the rpc
 			byte behaviorFlags = 0;
 			behaviorFlags |= replacePrevious ? RPC_BEHAVIOR_OVERWRITE : (byte)0;
@@ -1448,7 +1463,7 @@ namespace BeardedManStudios.Forge.Networking
 				lastUpdateTimestep = timeStep;
 			}
 		}
-        
+
 
         public void setProximityFields(bool useProximity, Receivers mode = Receivers.AllProximity)
         {


### PR DESCRIPTION
People on discord were asking for a convenience version of SendRpc where instead of one target player they could specify an array of players to send to.