### PR TITLE
Fixing NullReferenceException in MasterServer.exe when running as a headless service

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/ArgumentParser.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/ArgumentParser.cs
@@ -30,7 +30,7 @@ namespace BeardedManStudios
 		/// A dictionary of arguments with the key being the flag (or the index for floating args)
 		/// and the value being the associated value (or argument for floating args).
 		/// </returns>
-		public static Dictionary<string, string> Parse(params string[] args)
+		public static Dictionary<string, string> ParseArguments(params string[] args)
 		{
 			Dictionary<string, string> parsedArgs = new Dictionary<string, string>();
 
@@ -40,7 +40,7 @@ namespace BeardedManStudios
 				string arg = args[i];
 
 				string value;
-				string key = ParseArg(arg, out value) ?? floatingArgIndex++.ToString();
+				string key = ParseArgument(arg, out value) ?? floatingArgIndex++.ToString();
 
 				parsedArgs[key] = value;
 			}
@@ -66,7 +66,7 @@ namespace BeardedManStudios
 		/// <param name="arg"></param>
 		/// <param name="value"></param>
 		/// <returns></returns>
-		private static string ParseArg(string arg, out string value)
+		private static string ParseArgument(string arg, out string value)
 		{
 			if (arg == null)
 				throw new ArgumentNullException("arg");

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/ArgumentParser.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/ArgumentParser.cs
@@ -1,31 +1,84 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace BeardedManStudios
 {
-	// A simple dummy class for parsing the string arguments of a generic program, including flags
+	/// <summary>
+	/// A simple dummy class for parsing the string arguments of a generic program, including flags
+	/// </summary>
 	public static class ArgumentParser
 	{
 		/// <summary>
-		/// Parse a string array for the various arguments that were supplied
+		/// Matches:
+		///		-key
+		///		-key=value
+		///		--key
+		///		--key=value
+		/// </summary>
+		private const string ARGUMENT_PATTERN = @"^-{1,2}(?'key'[^\s=]+)(=(?'value'[^\s-=]+))?$";
+
+		/// <summary>
+		/// Parse a string array for the various arguments that were supplied.
+		/// For example:
+		///		["--a=1", "-b=2", "--c", "-d", "e", "f", "g"]
+		/// Results in:
+		///		{"a":"1", "b":"2", "c":null, "d":null, "0":"e", "1":"f", "2":"g"}
 		/// </summary>
 		/// <param name="args">The arguments that were sent to the program</param>
-		/// <returns>A dictionary of arguments with a key being the index or the flag starting with "-"</returns>
-		public static Dictionary<string, string> Parse(string[] args)
+		/// <returns>
+		/// A dictionary of arguments with the key being the flag (or the index for floating args)
+		/// and the value being the associated value (or argument for floating args).
+		/// </returns>
+		public static Dictionary<string, string> Parse(params string[] args)
 		{
 			Dictionary<string, string> parsedArgs = new Dictionary<string, string>();
 
 			int floatingArgIndex = 0;
 			for (int i = 0; i < args.Length; i++)
 			{
-				if (args[i].StartsWith("--"))
-					parsedArgs.Add(args[i], args[i]);
-				else if (args[i].StartsWith("-"))
-					parsedArgs.Add(args[i++], args[i]);
-				else
-					parsedArgs.Add((floatingArgIndex++).ToString(), args[i]);
+				string arg = args[i];
+
+				string value;
+				string key = ParseArg(arg, out value) ?? floatingArgIndex++.ToString();
+
+				parsedArgs[key] = value;
 			}
 
 			return parsedArgs;
+		}
+
+		/// <summary>
+		/// Given an input argument in one of the following formats:
+		/// 	-key
+		///		-key=value
+		///		--key
+		///		--key=value
+		///		value
+		/// 
+		/// Produces the following key/value pair:
+		///		{"key", null}
+		///		{"key", "value"}
+		///		{"key", null}
+		///		{"key", "value"}
+		///		{null, "value"}
+		/// </summary>
+		/// <param name="arg"></param>
+		/// <param name="value"></param>
+		/// <returns></returns>
+		private static string ParseArg(string arg, out string value)
+		{
+			if (arg == null)
+				throw new ArgumentNullException("arg");
+
+			value = arg;
+
+			Match match = Regex.Match(arg, ARGUMENT_PATTERN);
+			if (!match.Success)
+				return null;
+
+			value = match.Groups["value"].Value;
+			return match.Groups["key"].Value;
 		}
 	}
 }

--- a/MasterServer/MasterServer.cs
+++ b/MasterServer/MasterServer.cs
@@ -1,5 +1,4 @@
-﻿using BeardedManStudios;
-using BeardedManStudios.Forge.Networking;
+﻿using BeardedManStudios.Forge.Networking;
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Threading;
 using BeardedManStudios.SimpleJSON;
@@ -16,9 +15,9 @@ namespace MasterServer
 		private const int PING_INTERVAL = 10000;
 
 		public bool IsRunning { get; private set; }
-		private TCPServer server;
-		private List<Host> hosts = new List<Host>();
-		private Dictionary<string, int> _playerRequests = new Dictionary<string, int>();
+		private readonly TCPServer server;
+		private readonly List<Host> hosts = new List<Host>();
+		private readonly Dictionary<string, int> _playerRequests = new Dictionary<string, int>();
 		private bool _eloRangeSet;
 		private int _eloRange;
 		public int EloRange

--- a/MasterServer/Program.cs
+++ b/MasterServer/Program.cs
@@ -8,6 +8,7 @@ namespace MasterServer
 {
 	internal static class Program
 	{
+		private static bool s_Daemon = false;
 		private static string s_Host = "0.0.0.0";
 		private static ushort s_Port = 15940;
 		private static string s_Read = string.Empty;
@@ -29,7 +30,10 @@ namespace MasterServer
 			s_Server.ToggleLogging();
 
 			while (true)
-				HandleConsoleInput();
+			{
+				if (!s_Daemon)
+					HandleConsoleInput();
+			}
 		}
 
 		private static void ParseArgs(string[] args)
@@ -39,6 +43,9 @@ namespace MasterServer
 			if (args.Length > 0)
 			{
 				string value;
+				if (arguments.TryGetValue("d", out value) || arguments.TryGetValue("daemon", out value))
+					s_Daemon = true;
+
 				if (arguments.TryGetValue("h", out value) || arguments.TryGetValue("host", out value))
 					s_Host = value;
 

--- a/MasterServer/Program.cs
+++ b/MasterServer/Program.cs
@@ -11,7 +11,6 @@ namespace MasterServer
 		private static bool s_Daemon = false;
 		private static string s_Host = "0.0.0.0";
 		private static ushort s_Port = 15940;
-		private static string s_Read = string.Empty;
 		private static int s_EloRange = 0;
 
 		private static MasterServer s_Server;
@@ -59,15 +58,15 @@ namespace MasterServer
 			{
 				Console.WriteLine("Entering nothing will choose defaults.");
 				Console.WriteLine("Enter Host IP (Default: " + GetLocalIpAddress() + "):");
-				s_Read = Console.ReadLine();
-				s_Host = string.IsNullOrEmpty(s_Read) ? GetLocalIpAddress() : s_Read;
+				string read = Console.ReadLine();
+				s_Host = string.IsNullOrEmpty(read) ? GetLocalIpAddress() : read;
 
 				Console.WriteLine("Enter Port (Default: 15940):");
-				s_Read = Console.ReadLine();
-				if (string.IsNullOrEmpty(s_Read))
+				read = Console.ReadLine();
+				if (string.IsNullOrEmpty(read))
 					s_Port = 15940;
 				else
-					ushort.TryParse(s_Read, out s_Port);
+					ushort.TryParse(read, out s_Port);
 			}
 		}
 

--- a/MasterServer/Program.cs
+++ b/MasterServer/Program.cs
@@ -6,7 +6,7 @@ using System.Net.Sockets;
 
 namespace MasterServer
 {
-	class Program
+	internal static class Program
 	{
 		private static void Main(string[] args)
 		{
@@ -33,22 +33,17 @@ namespace MasterServer
 				Console.WriteLine("Entering nothing will choose defaults.");
 				Console.WriteLine("Enter Host IP (Default: "+ GetLocalIPAddress() + "):");
 				read = Console.ReadLine();
-				if (string.IsNullOrEmpty(read))
-					host = GetLocalIPAddress();
-				else
-					host = read;
+				host = string.IsNullOrEmpty(read) ? GetLocalIPAddress() : read;
 
 				Console.WriteLine("Enter Port (Default: 15940):");
 				read = Console.ReadLine();
 				if (string.IsNullOrEmpty(read))
 					port = 15940;
 				else
-				{
 					ushort.TryParse(read, out port);
-				}
 			}
 
-			Console.WriteLine(string.Format("Hosting ip [{0}] on port [{1}]", host, port));
+			Console.WriteLine("Hosting ip [{0}] on port [{1}]", host, port);
 			PrintHelp();
 			MasterServer server = new MasterServer(host, port);
 			server.EloRange = eloRange;
@@ -89,7 +84,7 @@ namespace MasterServer
 					}
 
 					Console.WriteLine("Restarting...");
-					Console.WriteLine(string.Format("Hosting ip [{0}] on port [{1}]", host, port));
+					Console.WriteLine("Hosting ip [{0}] on port [{1}]", host, port);
 					server = new MasterServer(host, port);
 				}
 				else if (read == "q" || read == "quit")
@@ -105,11 +100,11 @@ namespace MasterServer
 					PrintHelp();
 				else if (read.StartsWith("elo"))
 				{
-					int index = read.IndexOf("=");
+					int index = read.IndexOf("=", StringComparison.Ordinal);
 					string val = read.Substring(index + 1, read.Length - (index + 1));
 					if (int.TryParse(val.Replace(" ", string.Empty), out index))
 					{
-						Console.WriteLine(string.Format("Elo range set to {0}", index));
+						Console.WriteLine("Elo range set to {0}", index);
 						if (index == 0)
 							Console.WriteLine("Elo turned off");
 						server.EloRange = index;

--- a/MasterServer/Program.cs
+++ b/MasterServer/Program.cs
@@ -56,7 +56,12 @@ namespace MasterServer
 
 			while (true)
 			{
-				read = Console.ReadLine().ToLower();
+				read = Console.ReadLine()?.ToLower();
+
+				// Running as a headless server
+				if (read == null)
+					continue;
+
 				if (read == "s" || read == "stop")
 				{
 					lock (server)


### PR DESCRIPTION
I've been trying to run the MasterServer.exe as a systemd service on a headless ubuntu vm but I was getting a NullRef:

```[Unit]
Description=Forge Remastered Master Server
After=network.target

[Service]
ExecStart=/usr/bin/mono /opt/MasterServer/MasterServer.exe --port=15940

[Install]
WantedBy=multi-user.target
```

```* master-server.service - Forge Remastered Master Server
   Loaded: loaded (/etc/systemd/system/master-server.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Sat 2019-06-01 15:05:46 UTC; 9min ago
  Process: 1370 ExecStart=/usr/bin/mono /opt/MasterServer/MasterServer.exe --port=15940 (code=exited, status=1/FAILURE)
 Main PID: 1370 (code=exited, status=1/FAILURE)

Jun 01 15:05:46 unity mono[1370]: (h)elp - Get a full list of commands
Jun 01 15:05:46 unity mono[1370]: Unhandled Exception:
Jun 01 15:05:46 unity mono[1370]: System.NullReferenceException: Object reference not set to an instance of an object
Jun 01 15:05:46 unity mono[1370]:   at MasterServer.Program.Main (System.String[] args) [0x0011e] in <8ab1c2d1f70240f3925b91de964d747b>:0
Jun 01 15:05:46 unity mono[1370]: [ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
Jun 01 15:05:46 unity mono[1370]:   at MasterServer.Program.Main (System.String[] args) [0x0011e] in <8ab1c2d1f70240f3925b91de964d747b>:0
Jun 01 15:05:46 unity mono[1370]: WARNING: The runtime version supported by this application is unavailable.
Jun 01 15:05:46 unity mono[1370]: Using default runtime: v4.0.30319
Jun 01 15:05:46 unity systemd[1]: master-server.service: Main process exited, code=exited, status=1/FAILURE
Jun 01 15:05:46 unity systemd[1]: master-server.service: Failed with result 'exit-code'.
```

This change simply handles null input from the console properly.