### PR TITLE
SteamP2PServer has hardcoded lobby member count for the CreateLobby call

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/SteamP2PServer.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/SteamP2PServer.cs
@@ -183,7 +183,7 @@ namespace BeardedManStudios.Forge.Networking
                         func();
                 });
 
-                m_CreateLobbyResult = SteamMatchmaking.CreateLobby(lobbyType, 5);
+                m_CreateLobbyResult = SteamMatchmaking.CreateLobby(lobbyType, MaxConnections);
                 // Do any generic initialization in result of the successful bind
                 OnBindSuccessful();
 


### PR DESCRIPTION
Change to use the `NetWorker`'s `MaxConnections` as the maximum member count when calling the Steamworks API's `CreateLobby` method instead of it being hard coded to 5.