### PR TITLE
Fix Object instantiated at Vector3.zero and then slide to position when interpolation is on

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkManagerTemplate.txt
+++ b/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkManagerTemplate.txt
@@ -24,12 +24,12 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		    if (Networker != null)
 				Networker.objectCreated -= CaptureObjects;
 		}
-		
+
 		private void CaptureObjects(NetworkObject obj)
 		{
 			if (obj.CreateCode < 0)
 				return;
-				
+
 			>:FOREACH networkObjects:<
 			>:ELSEIF:< (obj is >:[i]:<NetworkObject)
 			{
@@ -47,7 +47,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 					if (newObj == null)
 						return;
-						
+
 					newObj.Initialize(obj);
 
 					if (objectInitialized != null)
@@ -66,21 +66,6 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		}
 
 		>:FOREACH networkObjects:<
-		[Obsolete("Use Instantiate>:[i]:< instead, its shorter and easier to type out ;)")]
-		public >:[i]:<Behavior Instantiate>:[i]:<NetworkObject(int index = 0, Vector3? position = null, Quaternion? rotation = null, bool sendTransform = true)
-		{
-			var go = Instantiate(>:[i]:<NetworkObject[index]);
-			var netBehavior = go.GetComponent<>:[i]:<Behavior>();
-			var obj = netBehavior.CreateNetworkObject(Networker, index);
-			go.GetComponent<>:[i]:<Behavior>().networkObject = (>:[i]:<NetworkObject)obj;
-
-			FinalizeInitialization(go, netBehavior, obj, position, rotation, sendTransform);
-			
-			return netBehavior;
-		}
-		>:ENDFOREACH:<
-
-		>:FOREACH networkObjects:<
 		/// <summary>
 		/// Instantiate an instance of >:[i]:<
 		/// </summary>
@@ -94,6 +79,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		public >:[i]:<Behavior Instantiate>:[i]:<(int index = 0, Vector3? position = null, Quaternion? rotation = null, bool sendTransform = true)
 		{
 			var go = Instantiate(>:[i]:<NetworkObject[index]);
+			go.SetActive(false);
 			var netBehavior = go.GetComponent<>:[i]:<Behavior>();
 
 			NetworkObject obj = null;
@@ -129,7 +115,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			go.GetComponent<>:[i]:<Behavior>().networkObject = (>:[i]:<NetworkObject)obj;
 
 			FinalizeInitialization(go, netBehavior, obj, position, rotation, sendTransform);
-			
+
 			return netBehavior;
 		}
 		>:ENDFOREACH:<

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/NetworkManager.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/NetworkManager.cs
@@ -415,9 +415,6 @@ namespace BeardedManStudios.Forge.Networking.Unity
 					go.transform.position = position.Value;
 			}
 
-			//if (sendTransform)
-			// obj.SendRpc(NetworkBehavior.RPC_SETUP_TRANSFORM, Receivers.AllBuffered, go.transform.position, go.transform.rotation);
-
 			if (!skipOthers)
 			{
 				// Go through all associated network behaviors in the hierarchy (including self) and
@@ -425,6 +422,8 @@ namespace BeardedManStudios.Forge.Networking.Unity
 				uint idOffset = 1;
 				ProcessOthers(go.transform, obj, ref idOffset, (NetworkBehavior)netBehavior);
 			}
+
+			go.SetActive(true);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Currently when position/rotation interpolation is on the instantiated object is first spawned at Vector3.zero and then gradually slides (interpolates) to the correct position.

This fix aims to resolve this by disabling the gameobject until instantiation is finalized by Forge.