### PR TITLE
[Fix] Android LAN Network Discovery

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/NetworkInterfaceAccumulator.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/NetworkInterfaceAccumulator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -36,17 +36,42 @@ namespace BeardedManStudios.Forge.Networking
 
 		private void AddNetworkInterfaceIfPossible(NetworkInterface nic, AddressFamily family)
 		{
-			switch (nic.NetworkInterfaceType)
+#if UNITY_ANDROID
+			switch ( nic.Name )
+			{
+				case "lo": // Localhost
+				case "wlan0": // Wifi
+					break;
+				default:
+					continue;
+			}
+
+			switch (nic.OperationalStatus)
+			{
+				case OperationalStatus.Up:
+				case OperationalStatus.Testing:
+				case OperationalStatus.Unknown:
+				case OperationalStatus.Dormant:
+					break;
+				case OperationalStatus.Down:
+				case OperationalStatus.NotPresent:
+				case OperationalStatus.LowerLayerDown:
+				default:
+					continue;
+			}
+#else
+			switch ( nic.NetworkInterfaceType )
 			{
 				case NetworkInterfaceType.Wireless80211:
 				case NetworkInterfaceType.Ethernet:
 					break;
 				default:
-					return;
+					continue;
 			}
 
-			if (nic.OperationalStatus != OperationalStatus.Up)
-				return;
+			if ( nic.OperationalStatus != OperationalStatus.Up )
+				continue;
+#endif
 
 			AddIfInFamily(nic, family);
 		}

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/NetworkInterfaceAccumulator.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/NetworkInterfaceAccumulator.cs
@@ -37,13 +37,13 @@ namespace BeardedManStudios.Forge.Networking
 		private void AddNetworkInterfaceIfPossible(NetworkInterface nic, AddressFamily family)
 		{
 #if UNITY_ANDROID
-			switch ( nic.Name )
+			switch (nic.Name)
 			{
 				case "lo": // Localhost
 				case "wlan0": // Wifi
 					break;
 				default:
-					continue;
+					return;
 			}
 
 			switch (nic.OperationalStatus)
@@ -57,20 +57,20 @@ namespace BeardedManStudios.Forge.Networking
 				case OperationalStatus.NotPresent:
 				case OperationalStatus.LowerLayerDown:
 				default:
-					continue;
+					return;
 			}
 #else
-			switch ( nic.NetworkInterfaceType )
+			switch (nic.NetworkInterfaceType)
 			{
 				case NetworkInterfaceType.Wireless80211:
 				case NetworkInterfaceType.Ethernet:
 					break;
 				default:
-					continue;
+					return;
 			}
 
-			if ( nic.OperationalStatus != OperationalStatus.Up )
-				continue;
+			if (nic.OperationalStatus != OperationalStatus.Up)
+				return;
 #endif
 
 			AddIfInFamily(nic, family);


### PR DESCRIPTION
The returned interfaces are all invalid/unknown because we don't have the rights to get the interfaces "states".

We know for our Android devices the names are either "lo" for "localhost" or "wlan0" for "wifi". Basically, the OperationalStatus will be Unknown, because you do not have the rights. But for safety, we still consider the other "valid" cases to be used.