### PR TITLE
[Fix] Android LAN Network Discovery

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/NetworkInterfaceAccumulator.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/NetworkInterfaceAccumulator.cs
@@ -36,6 +36,30 @@ namespace BeardedManStudios.Forge.Networking
 
 		private void AddNetworkInterfaceIfPossible(NetworkInterface nic, AddressFamily family)
 		{
+#if UNITY_ANDROID
+			switch (nic.Name)
+			{
+				case "lo": // Localhost
+				case "wlan0": // Wifi
+					break;
+				default:
+					return;
+			}
+
+			switch (nic.OperationalStatus)
+			{
+				case OperationalStatus.Up:
+				case OperationalStatus.Testing:
+				case OperationalStatus.Unknown:
+				case OperationalStatus.Dormant:
+					break;
+				case OperationalStatus.Down:
+				case OperationalStatus.NotPresent:
+				case OperationalStatus.LowerLayerDown:
+				default:
+					return;
+			}
+#else
 			switch (nic.NetworkInterfaceType)
 			{
 				case NetworkInterfaceType.Wireless80211:
@@ -47,6 +71,7 @@ namespace BeardedManStudios.Forge.Networking
 
 			if (nic.OperationalStatus != OperationalStatus.Up)
 				return;
+#endif
 
 			AddIfInFamily(nic, family);
 		}


### PR DESCRIPTION
The returned interfaces are all invalid/unknown because we don't have the rights to get the interfaces "states".

We know for our Android devices the names are either "lo" for "localhost" or "wlan0" for "wifi". Basically, the OperationalStatus will be Unknown, because you do not have the rights. But for safety, we still consider the other "valid" cases to be used.