### PR TITLE
Improve selection of local UDP port for client

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPClient.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPClient.cs
@@ -22,8 +22,10 @@ using BeardedManStudios.Forge.Networking.Nat;
 using BeardedManStudios.Threading;
 using System;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Threading;
+using System.Linq;
 
 namespace BeardedManStudios.Forge.Networking
 {
@@ -122,8 +124,13 @@ namespace BeardedManStudios.Forge.Networking
 				{
 					try
 					{
-						Client = new CachedUdpClient(clientPort);
-						break;
+						IPEndPoint[] activeEndPoints = IPGlobalProperties.GetIPGlobalProperties().GetActiveUdpListeners();
+						bool alreadyinuse = activeEndPoints.Any(p => p.Port == clientPort);
+						if(!alreadyinuse) 
+						{
+							Client = new CachedUdpClient(clientPort);
+							break;
+						}
 					}
 					catch
 					{


### PR DESCRIPTION
I'm developing a project where multiple clients will be created on the same server. 

What I've found is that as I launch each client, they will be just replace the previous one in the server, because clients are tracked by IP and source port and all the clients launched share the same port.

I've noticed that the existing UDPClient.cs code tries to select one local port. However a different one is only attempted if there's an exception.

I tried to add some additional checks (based on this answer on SO: https://stackoverflow.com/a/5879681/308705) and it now works (at least for me).

Hoping it will help someone else, I'm submitting this PR.

Cheers