### PR TITLE
join menu changes so disconnected hosts are removed.

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Multiplayer Menu/ServerListEntry.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Multiplayer Menu/ServerListEntry.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 
+[System.Serializable]
 public class ServerListEntry : MonoBehaviour
 {
 	public Text serverName;


### PR DESCRIPTION
- mostly changes around removing deactivated servers from the list. 

Other changes:

- Removed initial call to UpdateItem and just made the next tick really soon after creating the server entry as the old behavior would show new servers as disconnected for the first 5 seconds (maybe data wasn't in yet?).

- made some things public like the list of servers and made serializable. Allows visibility in the inspector as to what is going on.