### PR TITLE
Update NetworkBehaviorTemplate.txt to prevent objects from existing at 0,0,0 client side before warping to their initial location

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
+++ b/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
@@ -48,8 +48,7 @@ namespace BeardedManStudios.Forge.Networking.Generated
 				{
 					BMSByte metadataTransform = new BMSByte();
 					metadataTransform.Clone(obj.Metadata);
-					metadataTransform.MoveStartIndex(1);
-					gameObject.SetActive(false);
+					metadataTransform.MoveStartIndex(1);					
 
 					bool changePos = (transformFlags & 0x01) != 0;
                     bool changeRotation = (transformFlags & 0x02) != 0;

--- a/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
+++ b/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
@@ -49,6 +49,7 @@ namespace BeardedManStudios.Forge.Networking.Generated
 					BMSByte metadataTransform = new BMSByte();
 					metadataTransform.Clone(obj.Metadata);
 					metadataTransform.MoveStartIndex(1);
+					gameObject.SetActive(false);
 
 					bool changePos = (transformFlags & 0x01) != 0;
                     bool changeRotation = (transformFlags & 0x02) != 0;
@@ -67,6 +68,7 @@ namespace BeardedManStudios.Forge.Networking.Generated
 
 			MainThreadManager.Run(() =>
 			{
+				gameObject.SetActive(true);
 				NetworkStart();
 				networkObject.Networker.FlushCreateActions(networkObject);
 			});

--- a/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
+++ b/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
@@ -48,7 +48,7 @@ namespace BeardedManStudios.Forge.Networking.Generated
 				{
 					BMSByte metadataTransform = new BMSByte();
 					metadataTransform.Clone(obj.Metadata);
-					metadataTransform.MoveStartIndex(1);					
+					metadataTransform.MoveStartIndex(1);
 
 					bool changePos = (transformFlags & 0x01) != 0;
                     bool changeRotation = (transformFlags & 0x02) != 0;

--- a/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkManagerTemplate.txt
+++ b/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkManagerTemplate.txt
@@ -42,6 +42,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 						{
 							var go = Instantiate(>:[i]:<NetworkObject[obj.CreateCode]);
 							newObj = go.GetComponent<>:[i]:<Behavior>();
+							go.SetActive(false);
 						}
 					}
 


### PR DESCRIPTION
Client side fix for objects being spawned at 0,0,0 before warping to their proper starting location.