### PR TITLE
Unified asynchronous task usage

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/CommonServer.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/CommonServer.cs
@@ -110,7 +110,7 @@ namespace BeardedManStudios.Forge.Networking
 		public void CheckClientTimeout(Action<NetworkingPlayer> timeoutDisconnect)
 		{
 			List<NetworkingPlayer> timedoutPlayers = new List<NetworkingPlayer>();
-			while (server.IsBound)
+			while (server.IsActiveSession)
 			{
 				server.IteratePlayers((player) =>
 				{

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/NetworkingPlayer.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/NetworkingPlayer.cs
@@ -211,16 +211,16 @@ namespace BeardedManStudios.Forge.Networking
 				Port = (ushort)IPEndPointHandle.Port;
 			}
 
-			ThreadPool.QueueUserWorkItem(BackgroundServerPing);
+			Task.Queue(BackgroundServerPing);
 		}
 
-		private void BackgroundServerPing(object _)
+		private void BackgroundServerPing()
 		{
 			// There is no reason for the server to ping itself
 			if ((Networker is IServer))
 				return;
 
-			int waitTime = 0, currentPingWait = 0;
+			int waitTime = 100, currentPingWait = 0;
 			while (Networker.IsActiveSession)
 			{
 				Task.Sleep(waitTime);

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/SteamP2PClient.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/SteamP2PClient.cs
@@ -153,7 +153,7 @@ namespace BeardedManStudios.Forge.Networking
 						// Send the accept headers to the server to validate
 						Client.Send(connectHeader, connectHeader.Length, hostId, EP2PSend.k_EP2PSendUnreliable);
 						Thread.Sleep(3000);
-					} while (!initialConnectHeaderExchanged && IsBound && ++connectCounter < CONNECT_TRIES);
+					} while (!initialConnectHeaderExchanged && IsActiveSession && ++connectCounter < CONNECT_TRIES);
 
 					if (connectCounter >= CONNECT_TRIES)
 					{

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/SteamP2PServer.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/SteamP2PServer.cs
@@ -335,7 +335,7 @@ namespace BeardedManStudios.Forge.Networking
             BMSByte packet = null;
 
 			// Intentional infinite loop
-			while (IsBound)
+			while (IsActiveSession)
 			{
 				// If the read has been flagged to be canceled then break from this loop
 				if (IsReadThreadCancelPending)

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/UDPClient.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/UDPClient.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
 using BeardedManStudios.Forge.Networking.Frame;
 using BeardedManStudios.Forge.Networking.Nat;
 using BeardedManStudios.Threading;
@@ -101,7 +100,7 @@ namespace BeardedManStudios.Forge.Networking
 			return clientPort;
 		}
 
-		private void AttemptServerConnection(object _)
+		private void AttemptServerConnection()
 		{
 			int connectCounter = 0;
 
@@ -112,8 +111,8 @@ namespace BeardedManStudios.Forge.Networking
 			{
 				// Send the accept headers to the server to validate
 				Client.Send(connectHeader, connectHeader.Length, ServerPlayer.IPEndPointHandle);
-				Thread.Sleep(3000);
-			} while (!initialConnectHeaderExchanged && IsBound && ++connectCounter < CONNECT_TRIES);
+				Task.Sleep(3000);
+			} while (!initialConnectHeaderExchanged && IsActiveSession && ++connectCounter < CONNECT_TRIES);
 
 			if (connectCounter >= CONNECT_TRIES && connectAttemptFailed != null)
 				connectAttemptFailed(this);
@@ -172,7 +171,7 @@ namespace BeardedManStudios.Forge.Networking
 			SetNetworkBindings(overrideBindingPort, port, natHost, host, natPort);
 			CreateTheNetworkingPlayer(host, port);
 			SetupConnectingState();
-			ThreadPool.QueueUserWorkItem(AttemptServerConnection);
+			Task.Queue(AttemptServerConnection);
 		}
 
 		/// <summary>
@@ -245,7 +244,7 @@ namespace BeardedManStudios.Forge.Networking
 		{
 			try
 			{
-				while (IsBound)
+				while (IsActiveSession)
 				{
 					// If the read has been flagged to be canceled then break from this loop
 					if (IsReadThreadCancelPending)

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/UDPServer.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/UDPServer.cs
@@ -310,7 +310,7 @@ namespace BeardedManStudios.Forge.Networking
 			BMSByte packet = null;
 
 			// Intentional infinite loop
-			while (IsBound)
+			while (IsActiveSession)
 			{
 				// If the read has been flagged to be canceled then break from this loop
 				if (IsReadThreadCancelPending)


### PR DESCRIPTION
When debugging issue #322, I noticed a bit of inconsistency in task/thread management, especially when it comes to joining all background threads on shutdown/session reset. This pull request is aimed to improve this situation.

- use BeardedManStudios.Threading.Task for all task needs, instead of System.Threading directly;
- added thread join support: BMS.Threading.Task.WaitAll();
- in any infinite loops, use NetWorker.IsActiveSession checks instead of just IsBound, to cover EndingSession requests;
- NetWorker.EndSession now uses Task.WaitAll instead of an arbitrary 1s wait;
- fixed NetworkingPlayer.BackgroundServerPing to use non-zero wait time and actually ping the server.