### PR TITLE
Added the option to register rpc using the same approach as the NCW

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
+++ b/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
@@ -27,6 +27,7 @@ namespace BeardedManStudios.Forge.Networking.Generated
 			>:FOREVERY rpcs:<
 			networkObject.RegisterRpc(">:[0]:<", >:[0]:<>:[1]:<);
 			>:ENDFOREVERY:<
+			RegisterCustomRPCs(networkObject);
 
 			networkObject.onDestroy += DestroyGameObject;
 

--- a/ForgeUnity/Assets/BeardedManStudios/Examples/SceneUnloading/Scripts/SomeNetworkObject.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Examples/SceneUnloading/Scripts/SomeNetworkObject.cs
@@ -1,13 +1,32 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using BeardedManStudios.Forge.Networking;
 using BeardedManStudios.Forge.Networking.Generated;
+using BeardedManStudios.Forge.Networking.Unity;
 using UnityEngine;
 
 public class SomeNetworkObject : SomeMoveableBehavior
 {
+	private byte RPC_SERVER_TEST_RPC;
+
 	private float time;
 
-	void Update()
+	protected override void RegisterCustomRPCs(NetworkObject networkObject)
+	{
+		base.RegisterCustomRPCs(networkObject);
+
+		RPC_SERVER_TEST_RPC = networkObject.RegisterRpc("ServerTestRPC", ServerTestRPC, typeof(int), typeof(string));
+	}
+
+	protected override void NetworkStart()
+	{
+		base.NetworkStart();
+
+		networkObject.SendRpc(RPC_SERVER_TEST_RPC, Receivers.Server, 10, "Some string");
+	}
+
+	private void Update()
 	{
 		if (networkObject == null)
 			return;
@@ -22,5 +41,16 @@ public class SomeNetworkObject : SomeMoveableBehavior
 		{
 			transform.position = networkObject.position;
 		}
+	}
+
+	private void ServerTestRPC(RpcArgs args)
+	{
+		MainThreadManager.Run(() =>
+		{
+			int someValue = args.GetNext<int>();
+			string someString = args.GetNext<string>();
+
+			Debug.Log("Custom RPC Test: " + someValue + "  " + someString);
+		});
 	}
 }

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/NetworkBehavior.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/NetworkBehavior.cs
@@ -19,6 +19,7 @@ namespace BeardedManStudios.Forge.Networking.Unity
 		private uint waitingForNetworkObjectOffset;
 
 		public event NetworkBehaviorEvent networkStarted;
+		public Action<NetworkObject> registerCustomRPCs;
 
 		protected virtual void NetworkStart()
 		{
@@ -32,6 +33,11 @@ namespace BeardedManStudios.Forge.Networking.Unity
 
 		public abstract void Initialize(NetworkObject obj);
 		public abstract void Initialize(NetWorker networker, byte[] metadata = null);
+
+		protected virtual void RegisterCustomRPCs(NetworkObject networkObject)
+		{
+			registerCustomRPCs?.Invoke(networkObject);
+		}
 
 		public void AwaitNetworkBind(NetWorker networker, NetworkObject createTarget, uint idOffset)
 		{

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/Objects/NetworkObject.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/Objects/NetworkObject.cs
@@ -838,7 +838,8 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="methodName">The name of the method that is to be registered</param>
 		/// <param name="callback">The callback to fire for this RPC when received a signal for it</param>
 		/// <param name="argumentTypes">The types argument types for validation</param>
-		public void RegisterRpc(string methodName, Action<RpcArgs> callback, params Type[] argumentTypes)
+		/// <returns>The newly registered rpc id</returns>
+		public byte RegisterRpc(string methodName, Action<RpcArgs> callback, params Type[] argumentTypes)
 		{
 			// Make sure that the method name string is unique and not already assigned
 			if (rpcLookup.ContainsKey(methodName))
@@ -848,12 +849,13 @@ namespace BeardedManStudios.Forge.Networking
 			if (Rpcs.Count >= byte.MaxValue)
 				throw new BaseNetworkException("You are only allowed to register " + byte.MaxValue + " Rpc methods per network object");
 
-
 			// The id for this RPC is goign to be the next index in the dictionary
 			byte id = (byte)Rpcs.Count;
 			Rpcs.Add(id, new Rpc(callback, argumentTypes));
 			rpcLookup.Add(methodName, id);
 			inverseRpcLookup.Add(id, methodName);
+
+			return id;
 		}
 
 		/// <summary>


### PR DESCRIPTION
An example of this is in the SomeNetworkObject.cs used for additive scenes
There is a new function which you can override in a NetworkBehaviour called RegisterCustomRPCs(NetworkObject)

This is called before NetworkStart so the behaviour.networkObject will still be null at this time
hence why it has a argument NetworkObject which is a valid NetworkObject

Inside the RegisterCustomRPCs
you can register RPCs like you normally would except you have can register the RPC and you'll get the id back

for example

`
        private byte RPC_SERVER_TEST_RPC;

	protected override void RegisterCustomRPCs(NetworkObject networkObject)
	{
		base.RegisterCustomRPCs(networkObject);

		RPC_SERVER_TEST_RPC = networkObject.RegisterRpc("ServerTestRPC", ServerTestRPC, typeof(int), typeof(string));
	}
`

then like then you can use the RPC like you normally would

Aside from that you can also register rpcs from another MonoBehaviour
its completely the same as hooking into the 

networkBehaviour.networkStarted event but instead we have a custom one for registering rpcs which is networkBehaviour.registerCustomRPCs its completely the same as the parent one and is invoked just after RegisterCustomRPCs(NetworkObject networkObject)

-----------------------------------------------------------------------------------------
For as testing goes, I use this in Wobbly Life and works for very complicated NetworkBehaviours with multiple Monobehaviours registering rpcs

For testing in the current branch, I've added some example code in SomeNetworkObject.cs


