### PR TITLE
Refactor Connect() - give more control to developers

### DIFF
--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPClientBase.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPClientBase.cs
@@ -47,7 +47,7 @@ namespace BeardedManStudios.Forge.Networking
         protected NetworkingPlayer server = null;
         public NetworkingPlayer Server { get { return server; } }
 
-        public virtual void Connect(string host, ushort port = DEFAULT_PORT)
+        public virtual bool Connect(string host, ushort port = DEFAULT_PORT)
         {
             if (Disposed)
                 throw new ObjectDisposedException("TCPClient", "This object has been disposed and can not be used to connect, please use a new TCPClient");
@@ -68,11 +68,13 @@ namespace BeardedManStudios.Forge.Networking
                 {
                     connectAttemptFailed(this);
                 }
-                return;
+                return false;
             }
             // If we got this far then the bind was successful
             OnBindSuccessful();
             Initialize(host, port);
+
+			return true;
         }
         protected virtual void Initialize(string host, ushort port, bool pendCreates = true)
         {

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPClientWebsockets.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/TCPClientWebsockets.cs
@@ -50,12 +50,13 @@ namespace BeardedManStudios.Forge.Networking
 		[DllImport("__Internal")]
 		private static extern bool CheckSocketConnection();
 
-		public override void Connect(string host, ushort port = DEFAULT_PORT)
+		public override bool Connect(string host, ushort port = DEFAULT_PORT)
 		{
-			//Set the port
 			SetPort(port);
 
 			ForgeConnect(host, port);
+
+			return true;
 		}
 
 		public void CheckConnection()

--- a/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPClient.cs
+++ b/Forge Networking Remastered Unity/Assets/Bearded Man Studios Inc/Scripts/Networking/Forge/Networking/UDPClient.cs
@@ -101,7 +101,7 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="natHost">The NAT server host address, if blank NAT will be skipped</param>
 		/// <param name="natPort">The port that the NAT server is hosting on</param>
 		/// <param name="pendCreates">Immidiately set the NetWorker::PendCreates to true</param>
-		public void Connect(string host, ushort port = DEFAULT_PORT, string natHost = "", ushort natPort = NatHolePunch.DEFAULT_NAT_SERVER_PORT, bool pendCreates = false, ushort overrideBindingPort = DEFAULT_PORT + 1)
+		public bool Connect(string host, ushort port = DEFAULT_PORT, string natHost = "", ushort natPort = NatHolePunch.DEFAULT_NAT_SERVER_PORT, bool pendCreates = false, ushort overrideBindingPort = DEFAULT_PORT + 1)
 		{
 			if (Disposed)
 				throw new ObjectDisposedException("UDPClient", "This object has been disposed and can not be used to connect, please use a new UDPClient");
@@ -197,6 +197,8 @@ namespace BeardedManStudios.Forge.Networking
 
 				throw new FailedBindingException("Failed to bind to host/port, see inner exception", e);
 			}
+
+			return true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Clients' Connect() method should return at least bool so developers can verify if the method call was successful or not, without having to implement fail event handlers. Basically, now it forces developer to have the Connect() call as the last line in the method.