### PR TITLE
Refactor Connect() - give more control to developers

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/TCPClientBase.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/TCPClientBase.cs
@@ -36,7 +36,7 @@ namespace BeardedManStudios.Forge.Networking
 		protected NetworkingPlayer server = null;
 		public NetworkingPlayer ServerPlayer { get { return server; } }
 
-		public virtual void Connect(string host, ushort port = DEFAULT_PORT)
+		public virtual bool Connect(string host, ushort port = DEFAULT_PORT)
 		{
 			if (Disposed)
 				throw new ObjectDisposedException("TCPClient", "This object has been disposed and can not be used to connect, please use a new TCPClient");
@@ -57,11 +57,13 @@ namespace BeardedManStudios.Forge.Networking
 				{
 					connectAttemptFailed(this);
 				}
-				return;
+				return false;
 			}
 			// If we got this far then the bind was successful
 			OnBindSuccessful();
 			Initialize(host, port);
+
+			return true;
 		}
 		protected virtual void Initialize(string host, ushort port, bool pendCreates = true)
 		{

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/TCPClientWebsockets.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/TCPClientWebsockets.cs
@@ -31,12 +31,13 @@ namespace BeardedManStudios.Forge.Networking
 		[DllImport("__Internal")]
 		private static extern bool CheckSocketConnection();
 
-		public override void Connect(string host, ushort port = DEFAULT_PORT)
+		public override bool Connect(string host, ushort port = DEFAULT_PORT)
 		{
-			//Set the port
 			SetPort(port);
 
 			ForgeConnect(host, port);
+
+			return true;
 		}
 
 		public void CheckConnection()

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/UDPClient.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/UDPClient.cs
@@ -167,12 +167,12 @@ namespace BeardedManStudios.Forge.Networking
 			}
 		}
 
-		private void BindAndConnect(ushort overrideBindingPort, ushort port, string natHost, string host, ushort natPort)
+		private bool BindAndConnect(ushort overrideBindingPort, ushort port, string natHost, string host, ushort natPort)
 		{
 			SetNetworkBindings(overrideBindingPort, port, natHost, host, natPort);
 			CreateTheNetworkingPlayer(host, port);
 			SetupConnectingState();
-			ThreadPool.QueueUserWorkItem(AttemptServerConnection);
+			return ThreadPool.QueueUserWorkItem(AttemptServerConnection);
 		}
 
 		/// <summary>
@@ -183,7 +183,7 @@ namespace BeardedManStudios.Forge.Networking
 		/// <param name="natHost">The NAT server host address, if blank NAT will be skipped</param>
 		/// <param name="natPort">The port that the NAT server is hosting on</param>
 		/// <param name="pendCreates">Immidiately set the NetWorker::PendCreates to true</param>
-		public void Connect(string host, ushort port = DEFAULT_PORT, string natHost = "",
+		public bool Connect(string host, ushort port = DEFAULT_PORT, string natHost = "",
 			ushort natPort = NatHolePunch.DEFAULT_NAT_SERVER_PORT, bool pendCreates = false,
 			ushort overrideBindingPort = DEFAULT_PORT + 1)
 		{
@@ -199,7 +199,7 @@ namespace BeardedManStudios.Forge.Networking
 
 			try
 			{
-				BindAndConnect(overrideBindingPort, port, natHost, host, natPort);
+				return BindAndConnect(overrideBindingPort, port, natHost, host, natPort);
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
Clients' Connect() method should return at least bool so developers can verify if the method call was successful or not, without having to implement fail event handlers. Basically, now it forces developer to have the Connect() call as the last line in the method.