### PR TITLE
Fix for Unity's Configurable Enter Play Mode

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/MainThreadManager.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/MainThreadManager.cs
@@ -70,6 +70,11 @@ namespace BeardedManStudios.Forge.Networking.Unity
 			new GameObject("Main Thread Manager").AddComponent<MainThreadManager>();
 		}
 
+		private void OnDestroy()
+		{
+			_instance = null;
+		}
+
 		/// <summary>
 		/// A dictionary of action queues for different updates.
 		/// </summary>


### PR DESCRIPTION
When Unity's experimental Configurable Enter Play Mode (https://docs.unity3d.com/2019.3/Documentation/Manual/ConfigurableEnterPlayMode.html) is enabled static fields are not reinitialized to null.

This change makes Forge compatible with Configurable Enter Play Mode by clearing the static singleton _instance field when the MainThreadManager is destroyed on exiting play mode.

Replaces https://github.com/BeardedManStudios/ForgeNetworkingRemastered/pull/365 which was incorrectly targeted at master branch.