### PR TITLE
Add password user authenticator

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/PasswordUserAuthenticator.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/PasswordUserAuthenticator.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using BeardedManStudios;
+using BeardedManStudios.Forge.Networking;
+
+namespace BeardedManStudios.Forge.Networking
+{
+	/// <summary>
+	/// Authenticates the user to the server through a password.
+	/// </summary>
+	internal sealed class PasswordUserAuthenticator : IUserAuthenticator
+	{
+		/// <summary>
+		/// The password to require.
+		/// </summary>
+		private readonly string password;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="password">The password to require when connecting to the server.</param>
+		public PasswordUserAuthenticator(string password)
+		{
+			this.password = password;
+		}
+
+		/// <inheritdoc/>
+		public void IssueChallenge(
+			NetWorker networker,
+			NetworkingPlayer player,
+			Action<NetworkingPlayer, BMSByte> issueChallengeAction,
+			Action<NetworkingPlayer> skipAuthAction
+		)
+		{
+			issueChallengeAction(player, new BMSByte());
+		}
+
+		/// <inheritdoc/>
+		public void AcceptChallenge(
+			NetWorker networker,
+			BMSByte challenge,
+			Action<BMSByte> authServerAction,
+			Action rejectServerAction
+		)
+		{
+			authServerAction(ObjectMapper.BMSByte(password));
+		}
+
+		/// <inheritdoc/>
+		public void VerifyResponse(
+			NetWorker networker,
+			NetworkingPlayer player,
+			BMSByte response,
+			Action<NetworkingPlayer> authUserAction,
+			Action<NetworkingPlayer> rejectUserAction
+		)
+		{
+			string sentPassword = response.GetBasicType<string>();
+
+			if (sentPassword == password)
+				authUserAction(player);
+
+			else
+				rejectUserAction(player);
+		}
+	}
+}

--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/PasswordUserAuthenticator.cs.meta
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Networking/Forge/Networking/PasswordUserAuthenticator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aad506979d6256d4cbff1acb0ceee13c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
This adds a simple password user authenticator.

I followed the [wiki on authentication](https://github.com/BeardedManStudios/ForgeNetworkingRemastered/wiki/Basic-Authentication) to build this and tested it working. It wasn't hard to implement yourself, but password authentication seems like the most common use case most people will need, so this makes it slightly easier to get started.

I've combined client and server handling here as the most common use case is using Unity for everything, but this class can also be used on stand-alone non-Unity servers without changes. Seeing as clients only (appear to) need `AcceptChallenge`, it may be interesting to split `IUserAuthenticator` into a server and a client counterpart in the future.

Open question: do we need a timing-safe string comparison for security reasons? I did a quick search, but .NET does not appear to have this built-in, though I may have missed it.