### PR TITLE
Fix log folder generation failing with UnauthorizedAccessError on UWP

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Scripts/Logging/BMSLogger.cs
+++ b/ForgeUnity/Assets/BeardedManStudios/Scripts/Logging/BMSLogger.cs
@@ -47,7 +47,7 @@ public class BMSLogger : MonoBehaviour, IBMSLogger
 			return;
 
 #if !UNITY_IOS
-		string directory = Application.dataPath + "/" + SAVE_FILE_DIRECTORY_NAME;
+		string directory = Application.persistentDataPath + "/" + SAVE_FILE_DIRECTORY_NAME;
 		filepath = directory + SAVE_FILE_NAME;
 		if (!System.IO.Directory.Exists(directory))
 			System.IO.Directory.CreateDirectory(directory);


### PR DESCRIPTION
This happens immediately on startup, even if nothing is logged, because the folders are created and their path is inside the application directory in e.g. `Data/Logs`, which is read-only for security reasons on UWP - and will likely also be read-only when an app is installed versions on Linux distributions.

The exact error is:

```
UnauthorizedAccessException: Access to the path "C:/data/Programs/WindowsApps/unity-app_1.0.0.0_foo_abcdefghijk/Data/Logs" is denied.`

System.IO.Directory.CreateDirectoriesInternal (System.String path) <...>
System.IO.Directory.CreateDirectory (System.String path) <...>
BMSLogger.Init () <...>
```

This changes the path to use the persistent data path, which is writable, and on Windows something like `LocalAppData\unity-app_1.0.0.0_foo__abcdefghijk\LocalState\Logs\bmslog.txt`.