### PR TITLE
Destroy network object if behavior (or game object) is destroyed

### DIFF
--- a/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
+++ b/ForgeUnity/Assets/BeardedManStudios/Editor/Resources/BMS_Forge_Editor/NetworkBehaviorTemplate.txt
@@ -101,6 +101,12 @@ namespace BeardedManStudios.Forge.Networking.Generated
 			networkObject.SnapInterpolations();
 		}
 
+		private void OnDestroy()
+		{
+			networkObject.Destroy();
+			networkObject = null;
+		}
+
 		>:FOREVERY rpcs:<
 		/// <summary>
 		/// Arguments:


### PR DESCRIPTION
This seems kind of logical to me, but perhaps there is a reason that this doesn't happen currently?

The reverse already happens: destroying the network object will also destroy the game object.

I have application code that operates on game objects and has no knowledge of the network, which can remove game objects - that aren't always accompanied by network behaviors -, which currently causes them to linger around on other clients, as the network object isn't automatically destroyed along with the game object (or its behaviors). Not doing this would force me to make that code aware of the `networkObject` internals just to be able destroy it properly.

An alternative solution would be that I do this in a class that extends from this, but this seemed sufficiently desirable for everyone that I created this PR instead 😄.

