### PR TITLE
Clear _timedOutPlayers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ sysinfo.txt
 [cC]onsole[tT]est[pP]rogram/obj/
 
 [dD]ocs/mkdocs/[sS]ite/
+/ForgeAlloy/ForgeServerRegistryService/obj/Debug/netcoreapp3.0
+/ForgeAlloy/ForgeSampleGameServer/obj/Debug/netcoreapp3.0
+/ForgeAlloy/ForgeNatHolePunch/obj/Debug/netcoreapp3.0

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Players/ForgePlayerTimeoutBridge.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Players/ForgePlayerTimeoutBridge.cs
@@ -60,6 +60,7 @@ namespace Forge.Networking.Players
 				}
 				foreach (var player in _timedOutPlayers)
 					_networkMediator.PlayerRepository.RemovePlayer(player);
+				_timedOutPlayers.Clear();
 			}
 		}
 	}


### PR DESCRIPTION
The _timedOutPlayers should be cleared after they have been removed from the PlayerRepository