### PR TITLE
Thread safety and stop messages returning to pool too early

### DIFF
--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/ForgeNetworkMediator.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/ForgeNetworkMediator.cs
@@ -91,12 +91,12 @@ namespace Forge.Networking
 
 		public void SendReliableMessage(IMessage message, INetPlayer player)
 		{
-			MessageBus.SendMessage(message, SocketFacade.ManagedSocket, player.EndPoint);
+			MessageBus.SendReliableMessage(message, SocketFacade.ManagedSocket, player.EndPoint);
 		}
 
 		public void SendReliableMessage(IMessage message, EndPoint endpoint)
 		{
-			MessageBus.SendMessage(message, SocketFacade.ManagedSocket, endpoint);
+			MessageBus.SendReliableMessage(message, SocketFacade.ManagedSocket, endpoint);
 		}
 	}
 }

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessage.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessage.cs
@@ -9,8 +9,17 @@ namespace Forge.Networking.Messaging
 		public abstract IMessageInterpreter Interpreter { get; }
 		public abstract void Serialize(BMSByte buffer);
 		public abstract void Deserialize(BMSByte buffer);
+		public bool IsPooled { get; set; } = false;
+		public bool IsBuffered { get; set; } = false;
+		public bool IsSent { get; set; } = false;
 		public void Sent()
 		{
+			IsSent = true;
+			OnMessageSent?.Invoke(this);
+		}
+		public void Unbuffered()
+        {
+			IsBuffered = false;
 			OnMessageSent?.Invoke(this);
 		}
 	}

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageCodes.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageCodes.cs
@@ -53,6 +53,12 @@ namespace Forge.Networking.Messaging
 			return code;
 		}
 
+		public static T Instantiate<T>()
+        {
+			int code = GetCodeFromType(typeof(T));
+			return (T)Instantiate(code);
+        }
+
 		public static void Clear()
 		{
 			_messageTypes.Clear();

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepository.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/ForgeMessageRepository.cs
@@ -30,6 +30,7 @@ namespace Forge.Networking.Messaging
 			lock (_messages)
 			{
 				_messages.Clear();
+				// TODO: Need to unbuffer the messages, otherwise they will never return to message pool
 			}
 		}
 
@@ -74,6 +75,7 @@ namespace Forge.Networking.Messaging
 					kv = new Dictionary<IMessageReceiptSignature, IMessage>();
 					_messages.Add(sender, kv);
 				}
+				message.IsBuffered = true;
 				kv.Add(message.Receipt, message);
 			}
 		}
@@ -104,11 +106,24 @@ namespace Forge.Networking.Messaging
 
 		public void RemoveAllFor(EndPoint sender)
 		{
+			var copy = new List<IMessage>();
+
 			lock (_messages)
 			{
 				var removals = new List<IMessageReceiptSignature>();
+				if (_messages.TryGetValue(sender, out var kv))
+                {
+					foreach (var mkv in kv)
+						copy.Add(mkv.Value);
+				}
 				_messages.Remove(sender);
 			}
+
+			try
+			{
+				foreach (var m in copy) m.Unbuffered();
+			}
+			catch { }
 		}
 
 		public void RemoveMessage(EndPoint sender, IMessage message)
@@ -127,7 +142,14 @@ namespace Forge.Networking.Messaging
 			lock (_messages)
 			{
 				if (_messages.TryGetValue(sender, out var kv))
+				{
+					try
+					{
+						kv[receipt].Unbuffered();
+					}
+					catch { } // Catch just in case message already removed
 					kv.Remove(receipt);
+				}
 			}
 		}
 

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessage.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/IMessage.cs
@@ -12,5 +12,10 @@ namespace Forge.Networking.Messaging
 		void Serialize(BMSByte buffer);
 		void Deserialize(BMSByte buffer);
 		void Sent();
+		void Unbuffered();
+		bool IsPooled { get; set; }
+		bool IsBuffered { get; set; }
+		bool IsSent { get; set; }
+
 	}
 }

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/MessagePoolMulti.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Messaging/MessagePoolMulti.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Forge.Networking.Messaging
 {
 	public class MessagePoolMulti
 	{
-		private readonly Dictionary<Type, Queue<IMessage>> _messagePools = new Dictionary<Type, Queue<IMessage>>();
+		private readonly Dictionary<Type, ConcurrentQueue<IMessage>> _messagePools = new Dictionary<Type, ConcurrentQueue<IMessage>>();
 
 		public IMessage Get(Type t)
 		{
@@ -13,7 +14,16 @@ namespace Forge.Networking.Messaging
 			if (pool.Count == 0)
 				return CreateNewMessageForPool(t, pool);
 			else
-				return pool.Dequeue();
+			{
+				// Try to dequeue, but if locked default to create new
+				IMessage item;
+				if (pool.TryDequeue(out item))
+				{
+					item.IsPooled = false;
+					return item;
+				}
+				else return CreateNewMessageForPool(t, pool);
+			}
 		}
 
 		public T Get<T>() where T : IMessage, new()
@@ -22,27 +32,36 @@ namespace Forge.Networking.Messaging
 			if (pool.Count == 0)
 				return CreateNewMessageForPool<T>(pool);
 			else
-				return (T)pool.Dequeue();
+			{
+				// Try to dequeue, but if locked default to create new
+				IMessage item;
+				if (pool.TryDequeue(out item))
+				{
+					item.IsPooled = false;
+					return (T)item;
+				}
+				else return CreateNewMessageForPool<T>(pool);
+			}
 		}
 
-		private Queue<IMessage> GetPool(Type type)
+		private ConcurrentQueue<IMessage> GetPool(Type type)
 		{
 			if (!_messagePools.TryGetValue(type, out var pool))
 			{
-				pool = new Queue<IMessage>();
+				pool = new ConcurrentQueue<IMessage>();
 				_messagePools.Add(type, pool);
 			}
 			return pool;
 		}
 
-		private T CreateNewMessageForPool<T>(Queue<IMessage> pool) where T : IMessage, new()
+		private T CreateNewMessageForPool<T>(ConcurrentQueue<IMessage> pool) where T : IMessage, new()
 		{
 			T m = new T();
 			m.OnMessageSent += Release;
 			return m;
 		}
 
-		private IMessage CreateNewMessageForPool(Type t, Queue<IMessage> pool)
+		private IMessage CreateNewMessageForPool(Type t, ConcurrentQueue<IMessage> pool)
 		{
 			IMessage m = (IMessage)Activator.CreateInstance(t);
 			m.OnMessageSent += Release;
@@ -51,7 +70,13 @@ namespace Forge.Networking.Messaging
 
 		private void Release(IMessage message)
 		{
-			Queue<IMessage> pool = GetPool(message.GetType());
+			if (message.IsPooled) return; // Message has already been returned to pool
+			if (!message.IsSent) return;	// Message has not been sent, not ready to return to pool
+			if (message.IsBuffered) return; // Message is still buffered, not ready to return to pool
+			message.IsSent = false;
+			message.IsPooled = true;
+			message.Receipt = null;
+			ConcurrentQueue<IMessage> pool = GetPool(message.GetType());
 			pool.Enqueue(message);
 		}
 	}

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Players/ForgePlayerRepository.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Players/ForgePlayerRepository.cs
@@ -57,6 +57,11 @@ namespace Forge.Networking.Players
 			return _playerAddressLookup.TryGetValue(endpoint, out _);
 		}
 
+		public bool Exists(IPlayerSignature id)
+		{
+			return _playerLookup.TryGetValue(id, out _);
+		}
+
 		public IEnumerator<INetPlayer> GetEnumerator()
 		{
 			return _playerLookup.Values.GetEnumerator();

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Players/IPlayerRepository.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Networking/Players/IPlayerRepository.cs
@@ -102,6 +102,7 @@ namespace Forge.Networking.Players
 		/// </param>
 		/// <returns>True if the player matching the endpoint was found, otherwise false</returns>
 		bool Exists(EndPoint endpoint);
+		bool Exists(IPlayerSignature id);
 
 		/// <summary>
 		/// Used to get the internal enumerator of the repository

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Serialization/BMSBytePool.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/Serialization/BMSBytePool.cs
@@ -8,37 +8,50 @@ namespace Forge.Serialization
 		private const int APPROX_SIZE_ZONE = 128;
 		private readonly List<BMSByte> _availableBuffers = new List<BMSByte>();
 		private readonly List<BMSByte> _inUseBuffers = new List<BMSByte>();
+		private System.Object syncLock = new object();
 
 		public BMSByte Get(int size)
 		{
-			if (_availableBuffers.Count == 0)
-				return CreateNewBuffer(size);
-			else
+			BMSByte buff;
+
+			lock (syncLock)
 			{
-				BMSByte buff = GetAvailableBuffer(size);
-				if (buff.byteArr.Length < size)
-					buff.SetArraySize(size);
-				return buff;
+				if (_availableBuffers.Count == 0)
+					buff = CreateNewBuffer(size);
+				else
+				{
+					buff = GetAvailableBuffer(size);
+					if (buff.byteArr.Length < size)
+						buff.SetArraySize(size);
+				}
 			}
+			return buff;
 		}
 
 		public void Release(BMSByte buffer)
 		{
-			// TODO:  Figure out why _inUseBuffers.Remove(buffer) is returning false
 			bool found = false;
-			for (int i = 0; i < _inUseBuffers.Count; i++)
+
+			lock (syncLock)
 			{
-				if (_inUseBuffers[i] == buffer)
+				for (int i = 0; i < _inUseBuffers.Count; i++)
 				{
-					_inUseBuffers.RemoveAt(i);
-					found = true;
-					break;
+					if (_inUseBuffers[i] == buffer)
+					{
+						_inUseBuffers.RemoveAt(i);
+						found = true;
+						break;
+					}
+				}
+				if (found)
+                {
+					_availableBuffers.Add(buffer);
+					buffer.Clear();
 				}
 			}
 			if (!found)
 				throw new BMSBytePoolReleaseUnmanagedBufferException();
-			_availableBuffers.Add(buffer);
-			buffer.Clear();
+
 		}
 
 		private BMSByte GetAvailableBuffer(int size)

--- a/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/src/Entity/NetworkEntity.cs
+++ b/ForgeAlloy/ForgeAlloyUnity/Assets/ForgeNetworking/src/Entity/NetworkEntity.cs
@@ -35,11 +35,16 @@ namespace Forge.Networking.Unity
 
 		private void OnDestroy()
 		{
-			_engine.EntityRepository.Remove(this);
+			if (_engine.EntityRepository.Exists(this.Id))
+				_engine.EntityRepository.Remove(this);
 		}
 
 		private void OnValidate()
 		{
+
+			// OnValidate is only called in the editor
+			if (Application.isPlaying) return;
+
 			var entities = GameObject.FindObjectsOfType<NetworkEntity>();
 			List<string> _currentIds = entities.Where(e => e != this).Select(e => e._sceneIdentifier).ToList();
 			foreach (var e in entities)


### PR DESCRIPTION
- Messages added back to pool while still active in message bus stored messages and repeater lists.
- Make MessagePoolMulti thread safe as it is called from alloy networking thread and main thread
- Make BMSBytePool thread safe
- Two of the SendReliableMessage methods were not sending reliably
- ForgeUDPSocketServerFacade ChallengeSuccess assumed challenged players still exists in list. Changed to check entry exists. (Might be an issue unique to my project, ok to ignore unless you have same issue)
- Helper method in ForgeMessageCodes to instantiate message from message type (Can be ignored)
- Helper Method in IPlayerRepository to check if player signature exists (Can be ignored)

